### PR TITLE
fix(visualizer): repair broken sidebar layout and duplicate nav headers

### DIFF
--- a/Samples/01-overview.html
+++ b/Samples/01-overview.html
@@ -243,13 +243,14 @@
     .toast { position: fixed; bottom: 22px; right: 22px; z-index: 100; background: var(--panel-solid); border: 1px solid var(--border-strong); color: var(--text); padding: 12px 16px; border-radius: 10px; box-shadow: 0 16px 30px -12px rgba(0,0,0,0.6); font-size: 0.84rem; transform: translateY(20px); opacity: 0; transition: all .3s; pointer-events: none; }
     .toast.show { transform: none; opacity: 1; }
 
+    .scrim { display: none; }
     .mobile-only { display: none; }
     @media (max-width: 880px) {
       .app { grid-template-columns: 1fr; }
       .sidebar { position: fixed; left: 0; top: 0; width: 248px; transform: translateX(-100%); transition: transform .25s; box-shadow: 0 0 40px rgba(0,0,0,0.5); }
       .app.nav-open .sidebar { transform: none; }
       .mobile-only { display: grid; }
-      .scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
+      .scrim { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
       .app.nav-open .scrim { opacity: 1; pointer-events: auto; }
     }
 
@@ -360,14 +361,14 @@
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },
+    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
+    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
     { id:'audit',        title:'Audit Chain',     sub:'Merkle chain-of-custody & node explorer',   icon:'link', sec:'Forensics' },
     { id:'forensics',    title:'Forensics',       sub:'Entropy / KL analysis & security scan',     icon:'scan', sec:'Forensics' },
     { id:'waf',          title:'WAF & Limits',    sub:'Prompt-injection defense & rate limiting',  icon:'shield', sec:'Forensics' },
-    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
     { id:'compliance',   title:'Compliance',      sub:'SOC2 / HIPAA sealed export bundles',        icon:'doc', sec:'Governance' },
     { id:'architecture', title:'Architecture',    sub:'System topology & request lifecycle',       icon:'flow', sec:'Governance' },
     { id:'code',         title:'Code Map',        sub:'Python / Rust symbol explorer',             icon:'code', sec:'Governance' },
-    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
   ];
 
   const ICONS = {

--- a/Samples/01-overview.html
+++ b/Samples/01-overview.html
@@ -358,6 +358,10 @@
   };
 
   /* ----------------------------- Pages ----------------------------- */
+  // NOTE: PAGES drives the sidebar nav. Keep each `sec` group contiguous so
+  // buildNav() emits one header per section. After editing this array (or any
+  // markup/CSS in this file), regenerate the screenshot gallery so it stays in
+  // sync: `python tools/visualizer/generate_samples.py`.
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },

--- a/Samples/02-performance.html
+++ b/Samples/02-performance.html
@@ -243,13 +243,14 @@
     .toast { position: fixed; bottom: 22px; right: 22px; z-index: 100; background: var(--panel-solid); border: 1px solid var(--border-strong); color: var(--text); padding: 12px 16px; border-radius: 10px; box-shadow: 0 16px 30px -12px rgba(0,0,0,0.6); font-size: 0.84rem; transform: translateY(20px); opacity: 0; transition: all .3s; pointer-events: none; }
     .toast.show { transform: none; opacity: 1; }
 
+    .scrim { display: none; }
     .mobile-only { display: none; }
     @media (max-width: 880px) {
       .app { grid-template-columns: 1fr; }
       .sidebar { position: fixed; left: 0; top: 0; width: 248px; transform: translateX(-100%); transition: transform .25s; box-shadow: 0 0 40px rgba(0,0,0,0.5); }
       .app.nav-open .sidebar { transform: none; }
       .mobile-only { display: grid; }
-      .scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
+      .scrim { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
       .app.nav-open .scrim { opacity: 1; pointer-events: auto; }
     }
 
@@ -360,14 +361,14 @@
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },
+    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
+    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
     { id:'audit',        title:'Audit Chain',     sub:'Merkle chain-of-custody & node explorer',   icon:'link', sec:'Forensics' },
     { id:'forensics',    title:'Forensics',       sub:'Entropy / KL analysis & security scan',     icon:'scan', sec:'Forensics' },
     { id:'waf',          title:'WAF & Limits',    sub:'Prompt-injection defense & rate limiting',  icon:'shield', sec:'Forensics' },
-    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
     { id:'compliance',   title:'Compliance',      sub:'SOC2 / HIPAA sealed export bundles',        icon:'doc', sec:'Governance' },
     { id:'architecture', title:'Architecture',    sub:'System topology & request lifecycle',       icon:'flow', sec:'Governance' },
     { id:'code',         title:'Code Map',        sub:'Python / Rust symbol explorer',             icon:'code', sec:'Governance' },
-    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
   ];
 
   const ICONS = {

--- a/Samples/02-performance.html
+++ b/Samples/02-performance.html
@@ -358,6 +358,10 @@
   };
 
   /* ----------------------------- Pages ----------------------------- */
+  // NOTE: PAGES drives the sidebar nav. Keep each `sec` group contiguous so
+  // buildNav() emits one header per section. After editing this array (or any
+  // markup/CSS in this file), regenerate the screenshot gallery so it stays in
+  // sync: `python tools/visualizer/generate_samples.py`.
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },

--- a/Samples/03-audit.html
+++ b/Samples/03-audit.html
@@ -243,13 +243,14 @@
     .toast { position: fixed; bottom: 22px; right: 22px; z-index: 100; background: var(--panel-solid); border: 1px solid var(--border-strong); color: var(--text); padding: 12px 16px; border-radius: 10px; box-shadow: 0 16px 30px -12px rgba(0,0,0,0.6); font-size: 0.84rem; transform: translateY(20px); opacity: 0; transition: all .3s; pointer-events: none; }
     .toast.show { transform: none; opacity: 1; }
 
+    .scrim { display: none; }
     .mobile-only { display: none; }
     @media (max-width: 880px) {
       .app { grid-template-columns: 1fr; }
       .sidebar { position: fixed; left: 0; top: 0; width: 248px; transform: translateX(-100%); transition: transform .25s; box-shadow: 0 0 40px rgba(0,0,0,0.5); }
       .app.nav-open .sidebar { transform: none; }
       .mobile-only { display: grid; }
-      .scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
+      .scrim { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
       .app.nav-open .scrim { opacity: 1; pointer-events: auto; }
     }
 
@@ -360,14 +361,14 @@
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },
+    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
+    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
     { id:'audit',        title:'Audit Chain',     sub:'Merkle chain-of-custody & node explorer',   icon:'link', sec:'Forensics' },
     { id:'forensics',    title:'Forensics',       sub:'Entropy / KL analysis & security scan',     icon:'scan', sec:'Forensics' },
     { id:'waf',          title:'WAF & Limits',    sub:'Prompt-injection defense & rate limiting',  icon:'shield', sec:'Forensics' },
-    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
     { id:'compliance',   title:'Compliance',      sub:'SOC2 / HIPAA sealed export bundles',        icon:'doc', sec:'Governance' },
     { id:'architecture', title:'Architecture',    sub:'System topology & request lifecycle',       icon:'flow', sec:'Governance' },
     { id:'code',         title:'Code Map',        sub:'Python / Rust symbol explorer',             icon:'code', sec:'Governance' },
-    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
   ];
 
   const ICONS = {

--- a/Samples/03-audit.html
+++ b/Samples/03-audit.html
@@ -358,6 +358,10 @@
   };
 
   /* ----------------------------- Pages ----------------------------- */
+  // NOTE: PAGES drives the sidebar nav. Keep each `sec` group contiguous so
+  // buildNav() emits one header per section. After editing this array (or any
+  // markup/CSS in this file), regenerate the screenshot gallery so it stays in
+  // sync: `python tools/visualizer/generate_samples.py`.
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },

--- a/Samples/04-forensics.html
+++ b/Samples/04-forensics.html
@@ -243,13 +243,14 @@
     .toast { position: fixed; bottom: 22px; right: 22px; z-index: 100; background: var(--panel-solid); border: 1px solid var(--border-strong); color: var(--text); padding: 12px 16px; border-radius: 10px; box-shadow: 0 16px 30px -12px rgba(0,0,0,0.6); font-size: 0.84rem; transform: translateY(20px); opacity: 0; transition: all .3s; pointer-events: none; }
     .toast.show { transform: none; opacity: 1; }
 
+    .scrim { display: none; }
     .mobile-only { display: none; }
     @media (max-width: 880px) {
       .app { grid-template-columns: 1fr; }
       .sidebar { position: fixed; left: 0; top: 0; width: 248px; transform: translateX(-100%); transition: transform .25s; box-shadow: 0 0 40px rgba(0,0,0,0.5); }
       .app.nav-open .sidebar { transform: none; }
       .mobile-only { display: grid; }
-      .scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
+      .scrim { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
       .app.nav-open .scrim { opacity: 1; pointer-events: auto; }
     }
 
@@ -360,14 +361,14 @@
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },
+    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
+    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
     { id:'audit',        title:'Audit Chain',     sub:'Merkle chain-of-custody & node explorer',   icon:'link', sec:'Forensics' },
     { id:'forensics',    title:'Forensics',       sub:'Entropy / KL analysis & security scan',     icon:'scan', sec:'Forensics' },
     { id:'waf',          title:'WAF & Limits',    sub:'Prompt-injection defense & rate limiting',  icon:'shield', sec:'Forensics' },
-    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
     { id:'compliance',   title:'Compliance',      sub:'SOC2 / HIPAA sealed export bundles',        icon:'doc', sec:'Governance' },
     { id:'architecture', title:'Architecture',    sub:'System topology & request lifecycle',       icon:'flow', sec:'Governance' },
     { id:'code',         title:'Code Map',        sub:'Python / Rust symbol explorer',             icon:'code', sec:'Governance' },
-    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
   ];
 
   const ICONS = {

--- a/Samples/04-forensics.html
+++ b/Samples/04-forensics.html
@@ -358,6 +358,10 @@
   };
 
   /* ----------------------------- Pages ----------------------------- */
+  // NOTE: PAGES drives the sidebar nav. Keep each `sec` group contiguous so
+  // buildNav() emits one header per section. After editing this array (or any
+  // markup/CSS in this file), regenerate the screenshot gallery so it stays in
+  // sync: `python tools/visualizer/generate_samples.py`.
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },

--- a/Samples/05-waf.html
+++ b/Samples/05-waf.html
@@ -243,13 +243,14 @@
     .toast { position: fixed; bottom: 22px; right: 22px; z-index: 100; background: var(--panel-solid); border: 1px solid var(--border-strong); color: var(--text); padding: 12px 16px; border-radius: 10px; box-shadow: 0 16px 30px -12px rgba(0,0,0,0.6); font-size: 0.84rem; transform: translateY(20px); opacity: 0; transition: all .3s; pointer-events: none; }
     .toast.show { transform: none; opacity: 1; }
 
+    .scrim { display: none; }
     .mobile-only { display: none; }
     @media (max-width: 880px) {
       .app { grid-template-columns: 1fr; }
       .sidebar { position: fixed; left: 0; top: 0; width: 248px; transform: translateX(-100%); transition: transform .25s; box-shadow: 0 0 40px rgba(0,0,0,0.5); }
       .app.nav-open .sidebar { transform: none; }
       .mobile-only { display: grid; }
-      .scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
+      .scrim { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
       .app.nav-open .scrim { opacity: 1; pointer-events: auto; }
     }
 
@@ -360,14 +361,14 @@
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },
+    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
+    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
     { id:'audit',        title:'Audit Chain',     sub:'Merkle chain-of-custody & node explorer',   icon:'link', sec:'Forensics' },
     { id:'forensics',    title:'Forensics',       sub:'Entropy / KL analysis & security scan',     icon:'scan', sec:'Forensics' },
     { id:'waf',          title:'WAF & Limits',    sub:'Prompt-injection defense & rate limiting',  icon:'shield', sec:'Forensics' },
-    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
     { id:'compliance',   title:'Compliance',      sub:'SOC2 / HIPAA sealed export bundles',        icon:'doc', sec:'Governance' },
     { id:'architecture', title:'Architecture',    sub:'System topology & request lifecycle',       icon:'flow', sec:'Governance' },
     { id:'code',         title:'Code Map',        sub:'Python / Rust symbol explorer',             icon:'code', sec:'Governance' },
-    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
   ];
 
   const ICONS = {

--- a/Samples/05-waf.html
+++ b/Samples/05-waf.html
@@ -358,6 +358,10 @@
   };
 
   /* ----------------------------- Pages ----------------------------- */
+  // NOTE: PAGES drives the sidebar nav. Keep each `sec` group contiguous so
+  // buildNav() emits one header per section. After editing this array (or any
+  // markup/CSS in this file), regenerate the screenshot gallery so it stays in
+  // sync: `python tools/visualizer/generate_samples.py`.
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },

--- a/Samples/06-providers.html
+++ b/Samples/06-providers.html
@@ -243,13 +243,14 @@
     .toast { position: fixed; bottom: 22px; right: 22px; z-index: 100; background: var(--panel-solid); border: 1px solid var(--border-strong); color: var(--text); padding: 12px 16px; border-radius: 10px; box-shadow: 0 16px 30px -12px rgba(0,0,0,0.6); font-size: 0.84rem; transform: translateY(20px); opacity: 0; transition: all .3s; pointer-events: none; }
     .toast.show { transform: none; opacity: 1; }
 
+    .scrim { display: none; }
     .mobile-only { display: none; }
     @media (max-width: 880px) {
       .app { grid-template-columns: 1fr; }
       .sidebar { position: fixed; left: 0; top: 0; width: 248px; transform: translateX(-100%); transition: transform .25s; box-shadow: 0 0 40px rgba(0,0,0,0.5); }
       .app.nav-open .sidebar { transform: none; }
       .mobile-only { display: grid; }
-      .scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
+      .scrim { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
       .app.nav-open .scrim { opacity: 1; pointer-events: auto; }
     }
 
@@ -360,14 +361,14 @@
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },
+    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
+    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
     { id:'audit',        title:'Audit Chain',     sub:'Merkle chain-of-custody & node explorer',   icon:'link', sec:'Forensics' },
     { id:'forensics',    title:'Forensics',       sub:'Entropy / KL analysis & security scan',     icon:'scan', sec:'Forensics' },
     { id:'waf',          title:'WAF & Limits',    sub:'Prompt-injection defense & rate limiting',  icon:'shield', sec:'Forensics' },
-    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
     { id:'compliance',   title:'Compliance',      sub:'SOC2 / HIPAA sealed export bundles',        icon:'doc', sec:'Governance' },
     { id:'architecture', title:'Architecture',    sub:'System topology & request lifecycle',       icon:'flow', sec:'Governance' },
     { id:'code',         title:'Code Map',        sub:'Python / Rust symbol explorer',             icon:'code', sec:'Governance' },
-    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
   ];
 
   const ICONS = {

--- a/Samples/06-providers.html
+++ b/Samples/06-providers.html
@@ -358,6 +358,10 @@
   };
 
   /* ----------------------------- Pages ----------------------------- */
+  // NOTE: PAGES drives the sidebar nav. Keep each `sec` group contiguous so
+  // buildNav() emits one header per section. After editing this array (or any
+  // markup/CSS in this file), regenerate the screenshot gallery so it stays in
+  // sync: `python tools/visualizer/generate_samples.py`.
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },

--- a/Samples/07-compliance.html
+++ b/Samples/07-compliance.html
@@ -243,13 +243,14 @@
     .toast { position: fixed; bottom: 22px; right: 22px; z-index: 100; background: var(--panel-solid); border: 1px solid var(--border-strong); color: var(--text); padding: 12px 16px; border-radius: 10px; box-shadow: 0 16px 30px -12px rgba(0,0,0,0.6); font-size: 0.84rem; transform: translateY(20px); opacity: 0; transition: all .3s; pointer-events: none; }
     .toast.show { transform: none; opacity: 1; }
 
+    .scrim { display: none; }
     .mobile-only { display: none; }
     @media (max-width: 880px) {
       .app { grid-template-columns: 1fr; }
       .sidebar { position: fixed; left: 0; top: 0; width: 248px; transform: translateX(-100%); transition: transform .25s; box-shadow: 0 0 40px rgba(0,0,0,0.5); }
       .app.nav-open .sidebar { transform: none; }
       .mobile-only { display: grid; }
-      .scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
+      .scrim { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
       .app.nav-open .scrim { opacity: 1; pointer-events: auto; }
     }
 
@@ -360,14 +361,14 @@
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },
+    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
+    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
     { id:'audit',        title:'Audit Chain',     sub:'Merkle chain-of-custody & node explorer',   icon:'link', sec:'Forensics' },
     { id:'forensics',    title:'Forensics',       sub:'Entropy / KL analysis & security scan',     icon:'scan', sec:'Forensics' },
     { id:'waf',          title:'WAF & Limits',    sub:'Prompt-injection defense & rate limiting',  icon:'shield', sec:'Forensics' },
-    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
     { id:'compliance',   title:'Compliance',      sub:'SOC2 / HIPAA sealed export bundles',        icon:'doc', sec:'Governance' },
     { id:'architecture', title:'Architecture',    sub:'System topology & request lifecycle',       icon:'flow', sec:'Governance' },
     { id:'code',         title:'Code Map',        sub:'Python / Rust symbol explorer',             icon:'code', sec:'Governance' },
-    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
   ];
 
   const ICONS = {

--- a/Samples/07-compliance.html
+++ b/Samples/07-compliance.html
@@ -358,6 +358,10 @@
   };
 
   /* ----------------------------- Pages ----------------------------- */
+  // NOTE: PAGES drives the sidebar nav. Keep each `sec` group contiguous so
+  // buildNav() emits one header per section. After editing this array (or any
+  // markup/CSS in this file), regenerate the screenshot gallery so it stays in
+  // sync: `python tools/visualizer/generate_samples.py`.
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },

--- a/Samples/08-architecture.html
+++ b/Samples/08-architecture.html
@@ -243,13 +243,14 @@
     .toast { position: fixed; bottom: 22px; right: 22px; z-index: 100; background: var(--panel-solid); border: 1px solid var(--border-strong); color: var(--text); padding: 12px 16px; border-radius: 10px; box-shadow: 0 16px 30px -12px rgba(0,0,0,0.6); font-size: 0.84rem; transform: translateY(20px); opacity: 0; transition: all .3s; pointer-events: none; }
     .toast.show { transform: none; opacity: 1; }
 
+    .scrim { display: none; }
     .mobile-only { display: none; }
     @media (max-width: 880px) {
       .app { grid-template-columns: 1fr; }
       .sidebar { position: fixed; left: 0; top: 0; width: 248px; transform: translateX(-100%); transition: transform .25s; box-shadow: 0 0 40px rgba(0,0,0,0.5); }
       .app.nav-open .sidebar { transform: none; }
       .mobile-only { display: grid; }
-      .scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
+      .scrim { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
       .app.nav-open .scrim { opacity: 1; pointer-events: auto; }
     }
 
@@ -360,14 +361,14 @@
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },
+    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
+    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
     { id:'audit',        title:'Audit Chain',     sub:'Merkle chain-of-custody & node explorer',   icon:'link', sec:'Forensics' },
     { id:'forensics',    title:'Forensics',       sub:'Entropy / KL analysis & security scan',     icon:'scan', sec:'Forensics' },
     { id:'waf',          title:'WAF & Limits',    sub:'Prompt-injection defense & rate limiting',  icon:'shield', sec:'Forensics' },
-    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
     { id:'compliance',   title:'Compliance',      sub:'SOC2 / HIPAA sealed export bundles',        icon:'doc', sec:'Governance' },
     { id:'architecture', title:'Architecture',    sub:'System topology & request lifecycle',       icon:'flow', sec:'Governance' },
     { id:'code',         title:'Code Map',        sub:'Python / Rust symbol explorer',             icon:'code', sec:'Governance' },
-    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
   ];
 
   const ICONS = {

--- a/Samples/08-architecture.html
+++ b/Samples/08-architecture.html
@@ -358,6 +358,10 @@
   };
 
   /* ----------------------------- Pages ----------------------------- */
+  // NOTE: PAGES drives the sidebar nav. Keep each `sec` group contiguous so
+  // buildNav() emits one header per section. After editing this array (or any
+  // markup/CSS in this file), regenerate the screenshot gallery so it stays in
+  // sync: `python tools/visualizer/generate_samples.py`.
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },

--- a/Samples/09-code.html
+++ b/Samples/09-code.html
@@ -243,13 +243,14 @@
     .toast { position: fixed; bottom: 22px; right: 22px; z-index: 100; background: var(--panel-solid); border: 1px solid var(--border-strong); color: var(--text); padding: 12px 16px; border-radius: 10px; box-shadow: 0 16px 30px -12px rgba(0,0,0,0.6); font-size: 0.84rem; transform: translateY(20px); opacity: 0; transition: all .3s; pointer-events: none; }
     .toast.show { transform: none; opacity: 1; }
 
+    .scrim { display: none; }
     .mobile-only { display: none; }
     @media (max-width: 880px) {
       .app { grid-template-columns: 1fr; }
       .sidebar { position: fixed; left: 0; top: 0; width: 248px; transform: translateX(-100%); transition: transform .25s; box-shadow: 0 0 40px rgba(0,0,0,0.5); }
       .app.nav-open .sidebar { transform: none; }
       .mobile-only { display: grid; }
-      .scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
+      .scrim { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
       .app.nav-open .scrim { opacity: 1; pointer-events: auto; }
     }
 
@@ -360,14 +361,14 @@
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },
+    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
+    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
     { id:'audit',        title:'Audit Chain',     sub:'Merkle chain-of-custody & node explorer',   icon:'link', sec:'Forensics' },
     { id:'forensics',    title:'Forensics',       sub:'Entropy / KL analysis & security scan',     icon:'scan', sec:'Forensics' },
     { id:'waf',          title:'WAF & Limits',    sub:'Prompt-injection defense & rate limiting',  icon:'shield', sec:'Forensics' },
-    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
     { id:'compliance',   title:'Compliance',      sub:'SOC2 / HIPAA sealed export bundles',        icon:'doc', sec:'Governance' },
     { id:'architecture', title:'Architecture',    sub:'System topology & request lifecycle',       icon:'flow', sec:'Governance' },
     { id:'code',         title:'Code Map',        sub:'Python / Rust symbol explorer',             icon:'code', sec:'Governance' },
-    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
   ];
 
   const ICONS = {

--- a/Samples/09-code.html
+++ b/Samples/09-code.html
@@ -358,6 +358,10 @@
   };
 
   /* ----------------------------- Pages ----------------------------- */
+  // NOTE: PAGES drives the sidebar nav. Keep each `sec` group contiguous so
+  // buildNav() emits one header per section. After editing this array (or any
+  // markup/CSS in this file), regenerate the screenshot gallery so it stays in
+  // sync: `python tools/visualizer/generate_samples.py`.
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },

--- a/Samples/10-health.html
+++ b/Samples/10-health.html
@@ -243,13 +243,14 @@
     .toast { position: fixed; bottom: 22px; right: 22px; z-index: 100; background: var(--panel-solid); border: 1px solid var(--border-strong); color: var(--text); padding: 12px 16px; border-radius: 10px; box-shadow: 0 16px 30px -12px rgba(0,0,0,0.6); font-size: 0.84rem; transform: translateY(20px); opacity: 0; transition: all .3s; pointer-events: none; }
     .toast.show { transform: none; opacity: 1; }
 
+    .scrim { display: none; }
     .mobile-only { display: none; }
     @media (max-width: 880px) {
       .app { grid-template-columns: 1fr; }
       .sidebar { position: fixed; left: 0; top: 0; width: 248px; transform: translateX(-100%); transition: transform .25s; box-shadow: 0 0 40px rgba(0,0,0,0.5); }
       .app.nav-open .sidebar { transform: none; }
       .mobile-only { display: grid; }
-      .scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
+      .scrim { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
       .app.nav-open .scrim { opacity: 1; pointer-events: auto; }
     }
 
@@ -360,14 +361,14 @@
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },
+    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
+    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
     { id:'audit',        title:'Audit Chain',     sub:'Merkle chain-of-custody & node explorer',   icon:'link', sec:'Forensics' },
     { id:'forensics',    title:'Forensics',       sub:'Entropy / KL analysis & security scan',     icon:'scan', sec:'Forensics' },
     { id:'waf',          title:'WAF & Limits',    sub:'Prompt-injection defense & rate limiting',  icon:'shield', sec:'Forensics' },
-    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
     { id:'compliance',   title:'Compliance',      sub:'SOC2 / HIPAA sealed export bundles',        icon:'doc', sec:'Governance' },
     { id:'architecture', title:'Architecture',    sub:'System topology & request lifecycle',       icon:'flow', sec:'Governance' },
     { id:'code',         title:'Code Map',        sub:'Python / Rust symbol explorer',             icon:'code', sec:'Governance' },
-    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
   ];
 
   const ICONS = {

--- a/Samples/10-health.html
+++ b/Samples/10-health.html
@@ -358,6 +358,10 @@
   };
 
   /* ----------------------------- Pages ----------------------------- */
+  // NOTE: PAGES drives the sidebar nav. Keep each `sec` group contiguous so
+  // buildNav() emits one header per section. After editing this array (or any
+  // markup/CSS in this file), regenerate the screenshot gallery so it stays in
+  // sync: `python tools/visualizer/generate_samples.py`.
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },

--- a/Samples/index.html
+++ b/Samples/index.html
@@ -243,13 +243,14 @@
     .toast { position: fixed; bottom: 22px; right: 22px; z-index: 100; background: var(--panel-solid); border: 1px solid var(--border-strong); color: var(--text); padding: 12px 16px; border-radius: 10px; box-shadow: 0 16px 30px -12px rgba(0,0,0,0.6); font-size: 0.84rem; transform: translateY(20px); opacity: 0; transition: all .3s; pointer-events: none; }
     .toast.show { transform: none; opacity: 1; }
 
+    .scrim { display: none; }
     .mobile-only { display: none; }
     @media (max-width: 880px) {
       .app { grid-template-columns: 1fr; }
       .sidebar { position: fixed; left: 0; top: 0; width: 248px; transform: translateX(-100%); transition: transform .25s; box-shadow: 0 0 40px rgba(0,0,0,0.5); }
       .app.nav-open .sidebar { transform: none; }
       .mobile-only { display: grid; }
-      .scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
+      .scrim { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
       .app.nav-open .scrim { opacity: 1; pointer-events: auto; }
     }
 
@@ -360,14 +361,14 @@
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },
+    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
+    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
     { id:'audit',        title:'Audit Chain',     sub:'Merkle chain-of-custody & node explorer',   icon:'link', sec:'Forensics' },
     { id:'forensics',    title:'Forensics',       sub:'Entropy / KL analysis & security scan',     icon:'scan', sec:'Forensics' },
     { id:'waf',          title:'WAF & Limits',    sub:'Prompt-injection defense & rate limiting',  icon:'shield', sec:'Forensics' },
-    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
     { id:'compliance',   title:'Compliance',      sub:'SOC2 / HIPAA sealed export bundles',        icon:'doc', sec:'Governance' },
     { id:'architecture', title:'Architecture',    sub:'System topology & request lifecycle',       icon:'flow', sec:'Governance' },
     { id:'code',         title:'Code Map',        sub:'Python / Rust symbol explorer',             icon:'code', sec:'Governance' },
-    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
   ];
 
   const ICONS = {

--- a/Samples/index.html
+++ b/Samples/index.html
@@ -358,6 +358,10 @@
   };
 
   /* ----------------------------- Pages ----------------------------- */
+  // NOTE: PAGES drives the sidebar nav. Keep each `sec` group contiguous so
+  // buildNav() emits one header per section. After editing this array (or any
+  // markup/CSS in this file), regenerate the screenshot gallery so it stays in
+  // sync: `python tools/visualizer/generate_samples.py`.
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },

--- a/tools/visualizer/static/index.html
+++ b/tools/visualizer/static/index.html
@@ -354,6 +354,10 @@
   };
 
   /* ----------------------------- Pages ----------------------------- */
+  // NOTE: PAGES drives the sidebar nav. Keep each `sec` group contiguous so
+  // buildNav() emits one header per section. After editing this array (or any
+  // markup/CSS in this file), regenerate the screenshot gallery so it stays in
+  // sync: `python tools/visualizer/generate_samples.py`.
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },

--- a/tools/visualizer/static/index.html
+++ b/tools/visualizer/static/index.html
@@ -243,13 +243,14 @@
     .toast { position: fixed; bottom: 22px; right: 22px; z-index: 100; background: var(--panel-solid); border: 1px solid var(--border-strong); color: var(--text); padding: 12px 16px; border-radius: 10px; box-shadow: 0 16px 30px -12px rgba(0,0,0,0.6); font-size: 0.84rem; transform: translateY(20px); opacity: 0; transition: all .3s; pointer-events: none; }
     .toast.show { transform: none; opacity: 1; }
 
+    .scrim { display: none; }
     .mobile-only { display: none; }
     @media (max-width: 880px) {
       .app { grid-template-columns: 1fr; }
       .sidebar { position: fixed; left: 0; top: 0; width: 248px; transform: translateX(-100%); transition: transform .25s; box-shadow: 0 0 40px rgba(0,0,0,0.5); }
       .app.nav-open .sidebar { transform: none; }
       .mobile-only { display: grid; }
-      .scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
+      .scrim { display: block; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 25; opacity: 0; pointer-events: none; transition: opacity .25s; }
       .app.nav-open .scrim { opacity: 1; pointer-events: auto; }
     }
 
@@ -356,14 +357,14 @@
   const PAGES = [
     { id:'overview',     title:'Overview',        sub:'Real-time governance & forensic telemetry', icon:'grid', sec:'Operations' },
     { id:'performance',  title:'Performance',     sub:'Latency, throughput & acceleration',        icon:'gauge', sec:'Operations' },
+    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
+    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
     { id:'audit',        title:'Audit Chain',     sub:'Merkle chain-of-custody & node explorer',   icon:'link', sec:'Forensics' },
     { id:'forensics',    title:'Forensics',       sub:'Entropy / KL analysis & security scan',     icon:'scan', sec:'Forensics' },
     { id:'waf',          title:'WAF & Limits',    sub:'Prompt-injection defense & rate limiting',  icon:'shield', sec:'Forensics' },
-    { id:'providers',    title:'Providers',       sub:'Multi-provider routing & token economics',  icon:'plug', sec:'Operations' },
     { id:'compliance',   title:'Compliance',      sub:'SOC2 / HIPAA sealed export bundles',        icon:'doc', sec:'Governance' },
     { id:'architecture', title:'Architecture',    sub:'System topology & request lifecycle',       icon:'flow', sec:'Governance' },
     { id:'code',         title:'Code Map',        sub:'Python / Rust symbol explorer',             icon:'code', sec:'Governance' },
-    { id:'health',       title:'System Health',   sub:'Component status & security posture',        icon:'heart', sec:'Operations' },
   ];
 
   const ICONS = {


### PR DESCRIPTION
## Summary

- **Root cause 1 — Scrim grid intrusion**: `.scrim` (first child of `.app` CSS Grid) had no `display: none` in the base desktop CSS. It only received styles inside `@media (max-width: 880px)`, so on desktop it participated in the 2-column grid, occupying the first column (248px sidebar width) and pushing `.sidebar` to column 2 and `.main` off-screen. Fixed by adding `.scrim { display: none; }` to the base CSS and `display: block` inside the mobile media query.

- **Root cause 2 — Non-contiguous PAGES sections**: The `PAGES` array interleaved sections (Operations → Forensics → Operations → Governance → Operations), causing `buildNav()` to emit the "OPERATIONS" section header three times. Fixed by reordering to group all Operations pages first, then Forensics, then Governance.

- Regenerated `Samples/` with the corrected template.

## Test plan

- [ ] Open `tools/visualizer/static/index.html` via the dev server — sidebar renders in the left column, main content in the right
- [ ] Nav shows exactly one "OPERATIONS", one "FORENSICS", one "GOVERNANCE" section header
- [ ] On mobile (<880px) the scrim overlay still appears when the nav is open
- [ ] Sidebar collapse button and all 10 nav items work correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxGxKoBVPkovwBcfFtAfRA)_

## Summary by Sourcery

Fix visualizer navigation layout and regenerate sample pages.

Bug Fixes:
- Correct sidebar grid layout by hiding the scrim on desktop while preserving the mobile overlay behavior.
- Reorder visualizer page metadata so navigation sections render once each without duplicated headers across all sample pages.

Enhancements:
- Regenerate all visualizer sample HTML files to align with the corrected layout and navigation structure.