### PR TITLE
ci: fix cosign image reference parsing for Sigstore keyless signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,8 @@ jobs:
         uses: sigstore/cosign-installer@v3
 
       - name: Sign image (keyless Sigstore)
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          cosign sign --yes \
-            ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
+          IMAGE_REF="ghcr.io/${{ github.repository }}@${IMAGE_DIGEST}"
+          cosign sign --yes "${IMAGE_REF}"


### PR DESCRIPTION
## Summary
- Fixes cosign image reference parsing error in Docker build & push CI job
- Constructs image digest reference in environment variable to avoid GitHub Actions interpolation issues
- Ensures proper format for Sigstore keyless signing

## Test plan
- Run Docker build & push job on main or release event
- Verify cosign sign step completes without "parsing reference" error

🤖 Generated with [Claude Code](https://claude.ai/code/session_01FxGxKoBVPkovwBcfFtAfRA)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxGxKoBVPkovwBcfFtAfRA)_