### PR TITLE
fix: lowercase repository name for cosign image signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,5 +261,5 @@ jobs:
         env:
           IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          IMAGE_REF="ghcr.io/${{ github.repository }}@${IMAGE_DIGEST}"
+          IMAGE_REF="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')@${IMAGE_DIGEST}"
           cosign sign --yes "${IMAGE_REF}"


### PR DESCRIPTION
## Summary
- Fixes cosign image reference parsing error on Docker Build & Push job
- GHCR normalizes registry paths to lowercase, but `github.repository` preserves GitHub username casing
- Use `tr` to convert repository name to lowercase for proper cosign reference format

## Test plan
- Push to main or release event
- Verify Docker Build & Push job completes successfully with cosign signing

🤖 Generated with [Claude Code](https://claude.ai/code/session_01FxGxKoBVPkovwBcfFtAfRA)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxGxKoBVPkovwBcfFtAfRA)_