### PR TITLE
docs(readme): add theme-aware visual identity to guide readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 <div align="center">
 
-# Aegis Latent Core
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/hero-dark.svg">
+  <img alt="Aegis Latent Core — the verifiable control plane for every LLM call" src="docs/assets/hero-light.svg" width="100%">
+</picture>
 
-<img width="1920" height="1080" alt="Aegis Mission Control Dashboard" src="https://github.com/user-attachments/assets/949b1dce-bb52-4242-912f-cdcce074b411" />
+# Aegis Latent Core
 
 ### The AI Governance Proxy That Regulators Will Require and Enterprises Already Need
 
@@ -35,6 +38,15 @@ Standard application logs cannot satisfy this. They prove *that* a call was made
 **Aegis Latent Core is the infrastructure layer that closes this gap** — installed between your application and any LLM provider in minutes, with zero changes to existing client code, generating a SHA-256 hash-chained, HMAC-signed audit ledger on every inference. It is already aligned to FedRAMP High, DoD IL5/IL6, HIPAA, SOC 2 Type II, IEC 62443, and ISO 27001 control families. It ships with 10 detection engines that catch prompt injection, malware, leaked credentials, classified material, SCADA command injection, and adversarial suffixes — live, before the request reaches the model.
 
 **In a world where AI governance is not optional, Aegis is the layer that makes it verifiable.**
+
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/trust-dark.svg">
+  <img alt="Aligned to the frameworks that govern regulated AI: FedRAMP High, DoD IL5/IL6, HIPAA, SOC 2 Type II, ISO/IEC 42001, NIST SP 800-53, FIPS 204, IEC 62443, GDPR, 21 CFR Part 11" src="docs/assets/trust-light.svg" width="100%">
+</picture>
+
+</div>
 
 ---
 
@@ -233,6 +245,15 @@ curl -s -X POST http://localhost:8081/api/scan \
 ---
 
 ## The Mechanics — How Aegis Works (Without the PhD)
+
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/flow-dark.svg">
+  <img alt="How Aegis works in three steps: install in minutes with one env var, govern every call through auth and a 10-engine WAF, then prove every inference with a cryptographically-signed audit node sealed off the hot path" src="docs/assets/flow-light.svg" width="100%">
+</picture>
+
+</div>
 
 ### Two-Path Execution: Your Train, Our Security Camera
 
@@ -830,6 +851,12 @@ Spans: `aegis.auth`, `aegis.waf`, `aegis.forward`, `aegis.audit.commit`
 ## Mission Control Dashboard
 
 A 12-page enterprise dashboard for visualizing every aspect of Aegis in real time. Run it locally alongside the proxy.
+
+<div align="center">
+
+<img width="1920" height="1080" alt="Aegis Mission Control Dashboard — live KPIs, throughput, threat lab, audit chain, and compliance pages" src="https://github.com/user-attachments/assets/949b1dce-bb52-4242-912f-cdcce074b411" />
+
+</div>
 
 ```bash
 pip install -r tools/visualizer/requirements.txt

--- a/docs/assets/IMAGE_PROMPTS.md
+++ b/docs/assets/IMAGE_PROMPTS.md
@@ -1,0 +1,157 @@
+# README Image Prompts — copy-paste into ChatGPT / DALL·E / Midjourney
+
+This project already ships its own **vector visuals** (the hero banner, the
+compliance trust-strip and the "how it works" guide are the `*.svg` files in
+this folder — they render natively on GitHub in both light and dark mode). They
+are crisp at any size, weigh a few kilobytes each, and never call out to an
+external server.
+
+If you also want **photographic / rendered hero art** to drop in (a wide cover
+image, a section divider, social-preview card, etc.), the prompts below are
+written to be pasted straight into an image model. They assume the model knows
+**nothing** about this project, so each prompt fully describes the scene, style,
+palette, framing and what to avoid. Just copy a whole block.
+
+---
+
+## House style (applies to every prompt)
+
+- **Palette:** deep graphite / near-black background `#0d1117`, cool slate panels
+  `#161c26`, with a confident royal-blue `#2f5bea` and a teal-cyan `#0e8caa`
+  accent. Optional supporting hues: emerald `#1f9d6b`, soft amber `#bd7d0d`.
+  Mostly desaturated and calm; accent colour used sparingly.
+- **Mood:** institutional, trustworthy, precise — the visual language of an
+  enterprise security / compliance product, not a gaming or crypto brand.
+- **Lighting:** soft, even studio light with one gentle accent rim-light. No
+  harsh lens flares.
+- **Always avoid:** any text, letters, numbers, logos or watermarks (image
+  models render them as garbled glyphs); neon cyberpunk clichés; glowing green
+  "Matrix" code rain; cartoonish padlocks; stock-photo people in suits pointing
+  at floating holograms; busy clutter; heavy vignettes.
+- **Aspect ratio:** a wide README cover reads best around **1280 × 440 px**
+  (≈ 21:9). Section dividers ≈ **1280 × 240**. Social-preview card **1280 × 640**
+  (GitHub Open-Graph). State the ratio explicitly in your image tool.
+- **Export:** generate a light-background and a dark-background variant if you
+  want theme-aware swapping, then save as `docs/assets/<name>-light.png` /
+  `-dark.png` and reference them with a `<picture>` block like the SVGs in the
+  README.
+
+---
+
+## Prompt 1 — Primary hero cover ("the verifiable control plane")
+
+```
+A wide, ultra-clean enterprise technology hero image, 21:9 aspect ratio, for a
+software security product. Centre-right of the frame: an elegant 3D translucent
+shield made of frosted glass and brushed aluminium, floating in soft focus.
+Inside the shield, a neat vertical stack of small rounded rectangular "data
+blocks" is connected top-to-bottom by thin glowing links, like a chain of
+sealed ledger entries; a single small circular seal with a simple check mark
+glows at the top of the shield in royal blue. The background is a deep graphite
+near-black studio gradient (#0d1117) with an extremely subtle large-dot grid and
+one soft royal-blue (#2f5bea) and teal-cyan (#0e8caa) volumetric glow behind the
+shield. Minimalist, premium, lots of negative space on the left third for a
+title to be added later. Soft even lighting, gentle rim light on the shield
+edge, shallow depth of field. Corporate, trustworthy, high-end fintech /
+govtech aesthetic. Photorealistic 3D product render, octane-style, crisp.
+No text, no letters, no numbers, no logos, no watermark. No neon, no Matrix code,
+no cartoon padlocks.
+```
+
+## Prompt 2 — Tamper-evident audit chain (concept / section divider)
+
+```
+A clean, minimalist 3D illustration, very wide 21:9 banner, on a deep graphite
+background (#0d1117). A single horizontal chain of identical small frosted-glass
+cubes recedes into soft focus from left to right; each cube is linked to the
+next by a thin luminous royal-blue (#2f5bea) thread, and a faint cyan (#0e8caa)
+hash-pattern texture is etched on each face. One cube near the centre is lifted
+slightly and sealed with a tiny glowing wax-seal-style disc bearing a simple
+check mark. The composition suggests an unbreakable, ordered, sealed record.
+Generous empty space above and below. Soft studio lighting, subtle reflections
+on a dark matte floor, shallow depth of field. Premium, institutional, calm.
+Photorealistic product render. No text, no letters, no numbers, no logos, no
+watermark, no neon glow, no circuit-board clichés.
+```
+
+## Prompt 3 — Governance gateway / two-path flow
+
+```
+A premium isometric 3D diagram-style illustration, 21:9, on a dark slate
+gradient background (#0d1117 to #161c26). On the left, a stream of soft white
+glowing particles flows along a clean channel toward a central elegant gateway
+arch made of brushed metal and frosted glass. At the gateway, the stream passes
+through a thin translucent royal-blue (#2f5bea) filter membrane and continues to
+the right toward a softly glowing sphere (representing a remote service). Below
+the main channel, a separate, quieter secondary path branches downward into a
+small sealed vault cube with a cyan (#0e8caa) check-seal — clearly an
+"after the fact" side path, not blocking the main flow. Minimal, airy, lots of
+negative space, soft even lighting, subtle depth of field. Enterprise
+infrastructure aesthetic, trustworthy and precise. Photorealistic render.
+No text, no letters, no numbers, no logos, no watermark, no neon, no clutter.
+```
+
+## Prompt 4 — Regulated-industries mosaic (abstract, logo-free)
+
+```
+A sophisticated, abstract wide banner (21:9) on a deep graphite background
+(#0d1117) suggesting many regulated sectors protected under one system, WITHOUT
+any real logos or text. A softly lit grid of simple, elegant 3D glass icons
+floats in gentle perspective: a hospital cross, a bank/columned building, a
+government dome, a factory gear, a scales-of-justice, a microchip, a shield.
+Each icon is frosted glass with a thin royal-blue (#2f5bea) or teal-cyan
+(#0e8caa) edge light, arranged on an invisible grid with calm spacing. A faint
+network of thin lines connects them, and one subtle shield watermark sits behind
+the whole cluster. Muted, desaturated, premium, institutional. Soft studio
+lighting, shallow depth of field, lots of negative space. Photorealistic 3D
+render. No text, no letters, no numbers, no brand logos, no flags, no watermark,
+no neon, no people.
+```
+
+## Prompt 5 — Post-quantum seal (close-up focal image, square or 4:3)
+
+```
+A macro, photorealistic 3D product render of a single circular cryptographic
+"seal" medallion, 1:1 square framing, on a dark graphite background (#0d1117). The
+medallion is brushed titanium with a frosted royal-blue (#2f5bea) glass inlay and
+a simple engraved check mark at its centre; a fine concentric lattice pattern
+(suggesting a mathematical lattice) is etched into the metal rim, catching a soft
+cyan (#0e8caa) rim light. Tiny particles drift around it. Extremely clean,
+high-end, jewelry-product-photography lighting on a dark reflective surface,
+shallow depth of field, single soft key light plus gentle accent. Premium,
+serious, futuristic-but-restrained. No text, no letters, no numbers, no logos, no
+watermark, no neon glow, no cartoon style.
+```
+
+## Prompt 6 — Subtle section-divider texture (very wide, low-contrast)
+
+```
+An extremely subtle, low-contrast decorative divider strip, very wide panoramic
+ratio (about 6:1), on a deep graphite background (#0d1117). A faint horizontal
+field of tiny connected nodes and thin lines fades in from fully transparent
+edges, with a single soft royal-blue (#2f5bea) gradient glow drifting through the
+centre and a whisper of teal-cyan (#0e8caa). Mostly empty, atmospheric, calm —
+meant to sit quietly between sections of a document without competing for
+attention. Minimalist, elegant, premium. No text, no letters, no numbers, no
+logos, no watermark, no bright neon, no busy detail.
+```
+
+---
+
+## How to wire a generated raster image into the README
+
+```html
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/hero-photo-dark.png">
+  <img alt="Short, descriptive alt text of what the image shows" src="docs/assets/hero-photo-light.png" width="100%">
+</picture>
+
+</div>
+```
+
+Keep raster files reasonably small (target < 400 KB; export at ~1600 px wide and
+let the browser scale down). The committed SVGs remain the default; raster art is
+an optional enhancement you can swap in per section.
+```

--- a/docs/assets/flow-dark.svg
+++ b/docs/assets/flow-dark.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 408" width="1280" height="408" role="img" aria-label="How Aegis works — install, govern, prove">
+<defs><linearGradient id="fseal" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#5b7cff"/><stop offset="1" stop-color="#2bb6d6"/></linearGradient></defs>
+<text x="640" y="42" text-anchor="middle" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="14" font-weight="700" letter-spacing="3" fill="#5b7cff">HOW AEGIS WORKS</text>
+<rect x="64" y="74" width="360" height="296" rx="16" fill="#161c26" stroke="#27313f"/>
+<rect x="64" y="74" width="360" height="5" rx="2.5" fill="#5b7cff" opacity="0.9"/>
+<text x="398" y="140" text-anchor="end" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="46" font-weight="800" fill="#222c3a">01</text>
+<circle cx="114" cy="130" r="28" fill="#5b7cff" fill-opacity="0.10" stroke="#5b7cff" stroke-opacity="0.35"/>
+<g transform="translate(96,112) scale(1.5)" fill="none" stroke="#5b7cff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12 3 H19 a1 1 0 0 1 1 1 V20 a1 1 0 0 1 -1 1 H12 M3 12 H14 M10 8 l4 4 l-4 4"/>
+</g>
+<text x="92" y="206" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="21" font-weight="700" fill="#eef2f8">Install in minutes</text>
+<rect x="92" y="220" width="34" height="3" rx="1.5" fill="#5b7cff"/>
+<text x="92" y="252" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#9aa4b6">Point one environment variable at</text>
+<text x="92" y="275" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#9aa4b6">Aegis. Every existing OpenAI-SDK call</text>
+<text x="92" y="298" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#9aa4b6">is governed — with zero application</text>
+<text x="92" y="321" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#9aa4b6">code changes.</text>
+<path d="M 437 213 L 448 222 L 437 231" fill="none" stroke="#37425a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="460" y="74" width="360" height="296" rx="16" fill="#161c26" stroke="#27313f"/>
+<rect x="460" y="74" width="360" height="5" rx="2.5" fill="#5b7cff" opacity="0.9"/>
+<text x="794" y="140" text-anchor="end" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="46" font-weight="800" fill="#222c3a">02</text>
+<circle cx="510" cy="130" r="28" fill="#5b7cff" fill-opacity="0.10" stroke="#5b7cff" stroke-opacity="0.35"/>
+<g transform="translate(492,112) scale(1.5)" fill="none" stroke="#5b7cff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12 3 l8 3.2 V11 c0 4.6 -3.4 7.8 -8 9.6 C7.4 18.8 4 15.6 4 11 V6.2 Z"/>
+<path d="M8.6 11.2 l2.2 2.2 l4.6 -4.8"/>
+</g>
+<text x="488" y="206" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="21" font-weight="700" fill="#eef2f8">Govern every call</text>
+<rect x="488" y="220" width="34" height="3" rx="1.5" fill="#5b7cff"/>
+<text x="488" y="252" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#9aa4b6">Each request clears authentication, a</text>
+<text x="488" y="275" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#9aa4b6">10-engine threat WAF and per-tenant</text>
+<text x="488" y="298" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#9aa4b6">rate limits before it ever reaches the</text>
+<text x="488" y="321" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#9aa4b6">model.</text>
+<path d="M 833 213 L 844 222 L 833 231" fill="none" stroke="#37425a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="856" y="74" width="360" height="296" rx="16" fill="#161c26" stroke="#27313f"/>
+<rect x="856" y="74" width="360" height="5" rx="2.5" fill="#5b7cff" opacity="0.9"/>
+<text x="1190" y="140" text-anchor="end" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="46" font-weight="800" fill="#222c3a">03</text>
+<circle cx="906" cy="130" r="28" fill="#5b7cff" fill-opacity="0.10" stroke="#5b7cff" stroke-opacity="0.35"/>
+<g transform="translate(888,112) scale(1.5)" fill="none" stroke="#5b7cff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+<circle cx="12" cy="9.5" r="6.3"/>
+<path d="M8.5 11.5 l2.4 2.4 l4.6 -5"/>
+<path d="M8.5 15 L6.7 21 l5.3 -2.6 l5.3 2.6 l-1.8 -6"/>
+</g>
+<text x="884" y="206" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="21" font-weight="700" fill="#eef2f8">Prove every inference</text>
+<rect x="884" y="220" width="34" height="3" rx="1.5" fill="#5b7cff"/>
+<text x="884" y="252" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#9aa4b6">After the reply ships, a SHA-256</text>
+<text x="884" y="275" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#9aa4b6">hash-chained, HMAC + ML-DSA-signed</text>
+<text x="884" y="298" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#9aa4b6">audit node is sealed — entirely off</text>
+<text x="884" y="321" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#9aa4b6">the hot path.</text>
+</svg>

--- a/docs/assets/flow-light.svg
+++ b/docs/assets/flow-light.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 408" width="1280" height="408" role="img" aria-label="How Aegis works — install, govern, prove">
+<defs><linearGradient id="fseal" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#2f5bea"/><stop offset="1" stop-color="#0e8caa"/></linearGradient></defs>
+<text x="640" y="42" text-anchor="middle" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="14" font-weight="700" letter-spacing="3" fill="#2f5bea">HOW AEGIS WORKS</text>
+<rect x="64" y="74" width="360" height="296" rx="16" fill="#ffffff" stroke="#e4e7ec"/>
+<rect x="64" y="74" width="360" height="5" rx="2.5" fill="#2f5bea" opacity="0.9"/>
+<text x="398" y="140" text-anchor="end" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="46" font-weight="800" fill="#eaedf2">01</text>
+<circle cx="114" cy="130" r="28" fill="#2f5bea" fill-opacity="0.10" stroke="#2f5bea" stroke-opacity="0.35"/>
+<g transform="translate(96,112) scale(1.5)" fill="none" stroke="#2f5bea" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12 3 H19 a1 1 0 0 1 1 1 V20 a1 1 0 0 1 -1 1 H12 M3 12 H14 M10 8 l4 4 l-4 4"/>
+</g>
+<text x="92" y="206" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="21" font-weight="700" fill="#161d2c">Install in minutes</text>
+<rect x="92" y="220" width="34" height="3" rx="1.5" fill="#2f5bea"/>
+<text x="92" y="252" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#586173">Point one environment variable at</text>
+<text x="92" y="275" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#586173">Aegis. Every existing OpenAI-SDK call</text>
+<text x="92" y="298" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#586173">is governed — with zero application</text>
+<text x="92" y="321" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#586173">code changes.</text>
+<path d="M 437 213 L 448 222 L 437 231" fill="none" stroke="#d0d5dd" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="460" y="74" width="360" height="296" rx="16" fill="#ffffff" stroke="#e4e7ec"/>
+<rect x="460" y="74" width="360" height="5" rx="2.5" fill="#2f5bea" opacity="0.9"/>
+<text x="794" y="140" text-anchor="end" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="46" font-weight="800" fill="#eaedf2">02</text>
+<circle cx="510" cy="130" r="28" fill="#2f5bea" fill-opacity="0.10" stroke="#2f5bea" stroke-opacity="0.35"/>
+<g transform="translate(492,112) scale(1.5)" fill="none" stroke="#2f5bea" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12 3 l8 3.2 V11 c0 4.6 -3.4 7.8 -8 9.6 C7.4 18.8 4 15.6 4 11 V6.2 Z"/>
+<path d="M8.6 11.2 l2.2 2.2 l4.6 -4.8"/>
+</g>
+<text x="488" y="206" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="21" font-weight="700" fill="#161d2c">Govern every call</text>
+<rect x="488" y="220" width="34" height="3" rx="1.5" fill="#2f5bea"/>
+<text x="488" y="252" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#586173">Each request clears authentication, a</text>
+<text x="488" y="275" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#586173">10-engine threat WAF and per-tenant</text>
+<text x="488" y="298" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#586173">rate limits before it ever reaches the</text>
+<text x="488" y="321" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#586173">model.</text>
+<path d="M 833 213 L 844 222 L 833 231" fill="none" stroke="#d0d5dd" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="856" y="74" width="360" height="296" rx="16" fill="#ffffff" stroke="#e4e7ec"/>
+<rect x="856" y="74" width="360" height="5" rx="2.5" fill="#2f5bea" opacity="0.9"/>
+<text x="1190" y="140" text-anchor="end" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="46" font-weight="800" fill="#eaedf2">03</text>
+<circle cx="906" cy="130" r="28" fill="#2f5bea" fill-opacity="0.10" stroke="#2f5bea" stroke-opacity="0.35"/>
+<g transform="translate(888,112) scale(1.5)" fill="none" stroke="#2f5bea" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+<circle cx="12" cy="9.5" r="6.3"/>
+<path d="M8.5 11.5 l2.4 2.4 l4.6 -5"/>
+<path d="M8.5 15 L6.7 21 l5.3 -2.6 l5.3 2.6 l-1.8 -6"/>
+</g>
+<text x="884" y="206" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="21" font-weight="700" fill="#161d2c">Prove every inference</text>
+<rect x="884" y="220" width="34" height="3" rx="1.5" fill="#2f5bea"/>
+<text x="884" y="252" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#586173">After the reply ships, a SHA-256</text>
+<text x="884" y="275" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#586173">hash-chained, HMAC + ML-DSA-signed</text>
+<text x="884" y="298" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#586173">audit node is sealed — entirely off</text>
+<text x="884" y="321" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="500" fill="#586173">the hot path.</text>
+</svg>

--- a/docs/assets/hero-dark.svg
+++ b/docs/assets/hero-dark.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 440" width="1280" height="440" role="img" aria-label="Aegis Latent Core — the verifiable control plane for every LLM call">
+<defs>
+<linearGradient id="shield" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#161c26"/><stop offset="1" stop-color="#1c2330"/></linearGradient>
+<linearGradient id="seal" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#5b7cff"/><stop offset="1" stop-color="#2bb6d6"/></linearGradient>
+<radialGradient id="glow" cx="0.5" cy="0.42" r="0.62"><stop offset="0" stop-color="#5b7cff" stop-opacity="0.16"/><stop offset="1" stop-color="#5b7cff" stop-opacity="0"/></radialGradient>
+</defs>
+<rect x="828" y="40" width="412" height="380" rx="180" fill="url(#glow)"/>
+<text x="64" y="98" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" letter-spacing="3.5" fill="#5b7cff">AI&#160;&#160;GOVERNANCE&#160;&#160;PROXY</text>
+<text x="62" y="172" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="66" font-weight="800" letter-spacing="-1.5" fill="#eef2f8">Aegis Latent Core</text>
+<text x="64" y="224" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="23" font-weight="500" fill="#cdd5e2">The verifiable control plane for every LLM call.</text>
+<text x="64" y="258" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="17" font-weight="500" fill="#9aa4b6">OpenAI-compatible <tspan fill="#5f6a7e">·</tspan> zero code changes <tspan fill="#5f6a7e">·</tspan> cryptographically-signed audit chain</text>
+<rect x="64" y="296" width="204" height="38" rx="19" fill="#161c26" stroke="#27313f"/>
+<circle cx="86" cy="315" r="4.5" fill="#35c08a"/>
+<text x="102" y="320" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">5,451 tests passing</text>
+<rect x="280" y="296" width="172" height="38" rx="19" fill="#161c26" stroke="#27313f"/>
+<circle cx="302" cy="315" r="4.5" fill="#5b7cff"/>
+<text x="318" y="320" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">95.18% coverage</text>
+<rect x="464" y="296" width="188" height="38" rx="19" fill="#161c26" stroke="#27313f"/>
+<circle cx="486" cy="315" r="4.5" fill="#9483ff"/>
+<text x="502" y="320" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">10 threat engines</text>
+<rect x="664" y="296" width="204" height="38" rx="19" fill="#161c26" stroke="#27313f"/>
+<circle cx="686" cy="315" r="4.5" fill="#2bb6d6"/>
+<text x="702" y="320" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">post-quantum signed</text>
+<text x="64" y="392" font-family="'JetBrains Mono','SF Mono',ui-monospace,Menlo,Consolas,monospace" font-size="13" fill="#5f6a7e">AGPLv3 + Commercial  ·  Python 3.11–3.13  ·  Rust-accelerated  ·  v2.4.1</text>
+<path d="M 1042 74 C 1098 92, 1134 96, 1164 96 L 1164 206 C 1164 300, 1112 350, 1042 384 C 972 350, 920 300, 920 206 L 920 96 C 950 96, 986 92, 1042 74 Z" fill="url(#shield)" stroke="#37425a" stroke-width="1.5"/>
+<path d="M 1042 92 C 1090 107, 1120 110, 1146 110 L 1146 204 C 1146 286, 1102 330, 1042 360 C 982 330, 938 286, 938 204 L 938 110 C 964 110, 994 107, 1042 92 Z" fill="none" stroke="#5b7cff" stroke-opacity="0.16" stroke-width="1.2"/>
+<rect x="975" y="150" width="134" height="32" rx="8" fill="#1c2330" stroke="#27313f"/>
+<rect x="985" y="158" width="16" height="16" rx="4" fill="#5b7cff" fill-opacity="0.16" stroke="#5b7cff" stroke-opacity="0.55"/>
+<line x1="1009" y1="163" x2="1095" y2="163" stroke="#5f6a7e" stroke-width="3" stroke-linecap="round" stroke-opacity="0.7"/>
+<line x1="1009" y1="172" x2="1065" y2="172" stroke="#37425a" stroke-width="3" stroke-linecap="round"/>
+<rect x="1036" y="165" width="12" height="16" rx="3" fill="none" stroke="#37425a" stroke-width="2"/>
+<rect x="975" y="196" width="134" height="32" rx="8" fill="#1c2330" stroke="#27313f"/>
+<rect x="985" y="204" width="16" height="16" rx="4" fill="#5b7cff" fill-opacity="0.16" stroke="#5b7cff" stroke-opacity="0.55"/>
+<line x1="1009" y1="209" x2="1095" y2="209" stroke="#5f6a7e" stroke-width="3" stroke-linecap="round" stroke-opacity="0.7"/>
+<line x1="1009" y1="218" x2="1065" y2="218" stroke="#37425a" stroke-width="3" stroke-linecap="round"/>
+<rect x="1036" y="211" width="12" height="16" rx="3" fill="none" stroke="#37425a" stroke-width="2"/>
+<rect x="975" y="242" width="134" height="32" rx="8" fill="#1c2330" stroke="#27313f"/>
+<rect x="985" y="250" width="16" height="16" rx="4" fill="#5b7cff" fill-opacity="0.16" stroke="#5b7cff" stroke-opacity="0.55"/>
+<line x1="1009" y1="255" x2="1095" y2="255" stroke="#5f6a7e" stroke-width="3" stroke-linecap="round" stroke-opacity="0.7"/>
+<line x1="1009" y1="264" x2="1065" y2="264" stroke="#37425a" stroke-width="3" stroke-linecap="round"/>
+<rect x="1036" y="273" width="12" height="13" rx="3" fill="none" stroke="#37425a" stroke-width="2"/>
+<rect x="993" y="286" width="98" height="20" rx="6" fill="#1c2330" stroke="#27313f" stroke-dasharray="3 4" opacity="0.7"/>
+<circle cx="1042" cy="92" r="30" fill="#161c26"/>
+<circle cx="1042" cy="92" r="26" fill="url(#seal)"/>
+<path d="M 1031 92 l 7 8 l 15 -16" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs/assets/hero-light.svg
+++ b/docs/assets/hero-light.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 440" width="1280" height="440" role="img" aria-label="Aegis Latent Core — the verifiable control plane for every LLM call">
+<defs>
+<linearGradient id="shield" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#f6f8fb"/></linearGradient>
+<linearGradient id="seal" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#2f5bea"/><stop offset="1" stop-color="#0e8caa"/></linearGradient>
+<radialGradient id="glow" cx="0.5" cy="0.42" r="0.62"><stop offset="0" stop-color="#2f5bea" stop-opacity="0.16"/><stop offset="1" stop-color="#2f5bea" stop-opacity="0"/></radialGradient>
+</defs>
+<rect x="828" y="40" width="412" height="380" rx="180" fill="url(#glow)"/>
+<text x="64" y="98" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" letter-spacing="3.5" fill="#2f5bea">AI&#160;&#160;GOVERNANCE&#160;&#160;PROXY</text>
+<text x="62" y="172" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="66" font-weight="800" letter-spacing="-1.5" fill="#161d2c">Aegis Latent Core</text>
+<text x="64" y="224" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="23" font-weight="500" fill="#27314a">The verifiable control plane for every LLM call.</text>
+<text x="64" y="258" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="17" font-weight="500" fill="#586173">OpenAI-compatible <tspan fill="#9aa3b2">·</tspan> zero code changes <tspan fill="#9aa3b2">·</tspan> cryptographically-signed audit chain</text>
+<rect x="64" y="296" width="204" height="38" rx="19" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="86" cy="315" r="4.5" fill="#1f9d6b"/>
+<text x="102" y="320" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">5,451 tests passing</text>
+<rect x="280" y="296" width="172" height="38" rx="19" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="302" cy="315" r="4.5" fill="#2f5bea"/>
+<text x="318" y="320" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">95.18% coverage</text>
+<rect x="464" y="296" width="188" height="38" rx="19" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="486" cy="315" r="4.5" fill="#6b56d6"/>
+<text x="502" y="320" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">10 threat engines</text>
+<rect x="664" y="296" width="204" height="38" rx="19" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="686" cy="315" r="4.5" fill="#0e8caa"/>
+<text x="702" y="320" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">post-quantum signed</text>
+<text x="64" y="392" font-family="'JetBrains Mono','SF Mono',ui-monospace,Menlo,Consolas,monospace" font-size="13" fill="#9aa3b2">AGPLv3 + Commercial  ·  Python 3.11–3.13  ·  Rust-accelerated  ·  v2.4.1</text>
+<path d="M 1042 74 C 1098 92, 1134 96, 1164 96 L 1164 206 C 1164 300, 1112 350, 1042 384 C 972 350, 920 300, 920 206 L 920 96 C 950 96, 986 92, 1042 74 Z" fill="url(#shield)" stroke="#d0d5dd" stroke-width="1.5"/>
+<path d="M 1042 92 C 1090 107, 1120 110, 1146 110 L 1146 204 C 1146 286, 1102 330, 1042 360 C 982 330, 938 286, 938 204 L 938 110 C 964 110, 994 107, 1042 92 Z" fill="none" stroke="#2f5bea" stroke-opacity="0.16" stroke-width="1.2"/>
+<rect x="975" y="150" width="134" height="32" rx="8" fill="#f6f8fb" stroke="#e4e7ec"/>
+<rect x="985" y="158" width="16" height="16" rx="4" fill="#2f5bea" fill-opacity="0.16" stroke="#2f5bea" stroke-opacity="0.55"/>
+<line x1="1009" y1="163" x2="1095" y2="163" stroke="#9aa3b2" stroke-width="3" stroke-linecap="round" stroke-opacity="0.7"/>
+<line x1="1009" y1="172" x2="1065" y2="172" stroke="#d0d5dd" stroke-width="3" stroke-linecap="round"/>
+<rect x="1036" y="165" width="12" height="16" rx="3" fill="none" stroke="#d0d5dd" stroke-width="2"/>
+<rect x="975" y="196" width="134" height="32" rx="8" fill="#f6f8fb" stroke="#e4e7ec"/>
+<rect x="985" y="204" width="16" height="16" rx="4" fill="#2f5bea" fill-opacity="0.16" stroke="#2f5bea" stroke-opacity="0.55"/>
+<line x1="1009" y1="209" x2="1095" y2="209" stroke="#9aa3b2" stroke-width="3" stroke-linecap="round" stroke-opacity="0.7"/>
+<line x1="1009" y1="218" x2="1065" y2="218" stroke="#d0d5dd" stroke-width="3" stroke-linecap="round"/>
+<rect x="1036" y="211" width="12" height="16" rx="3" fill="none" stroke="#d0d5dd" stroke-width="2"/>
+<rect x="975" y="242" width="134" height="32" rx="8" fill="#f6f8fb" stroke="#e4e7ec"/>
+<rect x="985" y="250" width="16" height="16" rx="4" fill="#2f5bea" fill-opacity="0.16" stroke="#2f5bea" stroke-opacity="0.55"/>
+<line x1="1009" y1="255" x2="1095" y2="255" stroke="#9aa3b2" stroke-width="3" stroke-linecap="round" stroke-opacity="0.7"/>
+<line x1="1009" y1="264" x2="1065" y2="264" stroke="#d0d5dd" stroke-width="3" stroke-linecap="round"/>
+<rect x="1036" y="273" width="12" height="13" rx="3" fill="none" stroke="#d0d5dd" stroke-width="2"/>
+<rect x="993" y="286" width="98" height="20" rx="6" fill="#f6f8fb" stroke="#e4e7ec" stroke-dasharray="3 4" opacity="0.7"/>
+<circle cx="1042" cy="92" r="30" fill="#ffffff"/>
+<circle cx="1042" cy="92" r="26" fill="url(#seal)"/>
+<path d="M 1031 92 l 7 8 l 15 -16" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs/assets/trust-dark.svg
+++ b/docs/assets/trust-dark.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 150" width="1280" height="150" role="img" aria-label="Aligned to the frameworks that govern regulated AI">
+<text x="640" y="38" text-anchor="middle" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="14" font-weight="700" letter-spacing="3" fill="#5f6a7e">ALIGNED TO THE FRAMEWORKS THAT GOVERN REGULATED AI</text>
+<rect x="130" y="62" width="164" height="38" rx="10" fill="#161c26" stroke="#27313f"/>
+<circle cx="152" cy="81" r="4.5" fill="#5b7cff"/>
+<text x="168" y="86" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">FedRAMP High</text>
+<rect x="308" y="62" width="155" height="38" rx="10" fill="#161c26" stroke="#27313f"/>
+<circle cx="330" cy="81" r="4.5" fill="#9483ff"/>
+<text x="346" y="86" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">DoD IL5/IL6</text>
+<rect x="477" y="62" width="99" height="38" rx="10" fill="#161c26" stroke="#27313f"/>
+<circle cx="499" cy="81" r="4.5" fill="#ef6b7c"/>
+<text x="515" y="86" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">HIPAA</text>
+<rect x="590" y="62" width="174" height="38" rx="10" fill="#161c26" stroke="#27313f"/>
+<circle cx="612" cy="81" r="4.5" fill="#35c08a"/>
+<text x="628" y="86" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">SOC 2 Type II</text>
+<rect x="778" y="62" width="174" height="38" rx="10" fill="#161c26" stroke="#27313f"/>
+<circle cx="800" cy="81" r="4.5" fill="#2bb6d6"/>
+<text x="816" y="86" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">ISO/IEC 42001</text>
+<rect x="966" y="62" width="183" height="38" rx="10" fill="#161c26" stroke="#27313f"/>
+<circle cx="988" cy="81" r="4.5" fill="#5b7cff"/>
+<text x="1004" y="86" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">NIST SP 800-53</text>
+<rect x="333" y="114" width="164" height="38" rx="10" fill="#161c26" stroke="#27313f"/>
+<circle cx="355" cy="133" r="4.5" fill="#e0a93a"/>
+<text x="371" y="138" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">FIPS 204 PQC</text>
+<rect x="511" y="114" width="136" height="38" rx="10" fill="#161c26" stroke="#27313f"/>
+<circle cx="533" cy="133" r="4.5" fill="#35c08a"/>
+<text x="549" y="138" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">IEC 62443</text>
+<rect x="661" y="114" width="89" height="38" rx="10" fill="#161c26" stroke="#27313f"/>
+<circle cx="683" cy="133" r="4.5" fill="#9483ff"/>
+<text x="699" y="138" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">GDPR</text>
+<rect x="764" y="114" width="183" height="38" rx="10" fill="#161c26" stroke="#27313f"/>
+<circle cx="786" cy="133" r="4.5" fill="#2bb6d6"/>
+<text x="802" y="138" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#cdd5e2">21 CFR Part 11</text>
+</svg>

--- a/docs/assets/trust-light.svg
+++ b/docs/assets/trust-light.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 150" width="1280" height="150" role="img" aria-label="Aligned to the frameworks that govern regulated AI">
+<text x="640" y="38" text-anchor="middle" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="14" font-weight="700" letter-spacing="3" fill="#9aa3b2">ALIGNED TO THE FRAMEWORKS THAT GOVERN REGULATED AI</text>
+<rect x="130" y="62" width="164" height="38" rx="10" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="152" cy="81" r="4.5" fill="#2f5bea"/>
+<text x="168" y="86" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">FedRAMP High</text>
+<rect x="308" y="62" width="155" height="38" rx="10" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="330" cy="81" r="4.5" fill="#6b56d6"/>
+<text x="346" y="86" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">DoD IL5/IL6</text>
+<rect x="477" y="62" width="99" height="38" rx="10" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="499" cy="81" r="4.5" fill="#d6485a"/>
+<text x="515" y="86" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">HIPAA</text>
+<rect x="590" y="62" width="174" height="38" rx="10" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="612" cy="81" r="4.5" fill="#1f9d6b"/>
+<text x="628" y="86" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">SOC 2 Type II</text>
+<rect x="778" y="62" width="174" height="38" rx="10" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="800" cy="81" r="4.5" fill="#0e8caa"/>
+<text x="816" y="86" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">ISO/IEC 42001</text>
+<rect x="966" y="62" width="183" height="38" rx="10" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="988" cy="81" r="4.5" fill="#2f5bea"/>
+<text x="1004" y="86" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">NIST SP 800-53</text>
+<rect x="333" y="114" width="164" height="38" rx="10" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="355" cy="133" r="4.5" fill="#bd7d0d"/>
+<text x="371" y="138" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">FIPS 204 PQC</text>
+<rect x="511" y="114" width="136" height="38" rx="10" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="533" cy="133" r="4.5" fill="#1f9d6b"/>
+<text x="549" y="138" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">IEC 62443</text>
+<rect x="661" y="114" width="89" height="38" rx="10" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="683" cy="133" r="4.5" fill="#6b56d6"/>
+<text x="699" y="138" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">GDPR</text>
+<rect x="764" y="114" width="183" height="38" rx="10" fill="#ffffff" stroke="#e4e7ec"/>
+<circle cx="786" cy="133" r="4.5" fill="#0e8caa"/>
+<text x="802" y="138" font-family="'Inter','Segoe UI',system-ui,-apple-system,Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="600" fill="#27314a">21 CFR Part 11</text>
+</svg>


### PR DESCRIPTION
## What

Elevate the README's visual appeal with a cohesive, professional visual identity that guides readers through the project. All visuals are **static, theme-aware SVGs** that render natively on GitHub in both light and dark mode — crisp at any size, a few KB each, with **no external dependencies** and no scripts/animations (sanitizer-safe).

### New visuals (`docs/assets/`)

| Asset | Purpose | Placement |
|---|---|---|
| `hero-{light,dark}.svg` | Shield + sealed ledger-chain motif, tagline, stat pills | Top of README |
| `trust-{light,dark}.svg` | Compliance frameworks that govern regulated AI | After the regulatory pitch |
| `flow-{light,dark}.svg` | 3-step "Install → Govern → Prove" guide | Start of the Mechanics section |

Each is wired in with a `<picture>` element (`prefers-color-scheme`) so it follows the reader's GitHub theme. Design language matches the BI dashboard: calm graphite dark / clean light, royal-blue accent — no neon.

### Other changes

- Relocated the **Mission Control screenshot** from the top into the *Mission Control Dashboard* section it actually illustrates.
- Added **`docs/assets/IMAGE_PROMPTS.md`** — large, self-contained prompts (house style + 6 scene prompts) for optionally generating complementary photoreal hero art in ChatGPT / DALL·E / Midjourney, plus how to wire raster art into the README.

## Verification

- All six SVGs validated as well-formed XML and free of sanitizer-stripped elements (`<script>`, `<style>`, `onload`, `<foreignObject>`).
- Rendered each variant to PNG on representative GitHub backgrounds (`#ffffff` / `#0d1117`) and reviewed; chip wrapping and text fit confirmed in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxGxKoBVPkovwBcfFtAfRA

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxGxKoBVPkovwBcfFtAfRA)_