### PR TITLE
CI: fix source SBOM generation on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
   sbom:
     name: Generate SBOM
     runs-on: ubuntu-22.04
-    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: github.event_name == 'pull_request' || github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [test, security, market-hardening]
     permissions:
       contents: read
@@ -350,13 +350,18 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Build source artifact
-        run: git archive --format=tar.gz --output="aegis-source-${GITHUB_SHA}.tar.gz" HEAD
+        run: |
+          set -euo pipefail
+          mkdir sbom-root
+          git archive --format=tar.gz --output="aegis-source-${GITHUB_SHA}.tar.gz" HEAD
+          tar -xzf "aegis-source-${GITHUB_SHA}.tar.gz" -C sbom-root
       - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
-          path: aegis-source-${{ github.sha }}.tar.gz
+          path: sbom-root
           format: spdx-json
           output-file: sbom.spdx.json
       - name: Attest source SBOM
+        if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         uses: actions/attest-sbom@bd218ad0dbcb3e146bd073d1d9c6d78e08aa8a0b # v2
         with:
           subject-path: aegis-source-${{ github.sha }}.tar.gz


### PR DESCRIPTION
## Root cause

The first `main`-only SBOM run passed a `.tar.gz` file to `anchore/sbom-action` through its `path` input. The action resolved this as `dir:<archive>`, so Syft failed because an archive is not a directory.

## Fix

- Extract the deterministic `git archive` into `sbom-root/` and point Syft at that directory.
- Run SBOM generation on pull requests so source catalog failures are caught before merge.
- Keep the OIDC-backed SBOM attestation restricted to `main` pushes and releases.

## Validation

- GitHub Actions pin verifier: 76/76 remote references pinned to full SHAs.
- Workflow YAML parsed and asserted locally.
- Syft 1.42.3 downloaded with upstream SHA-256 verification and successfully generated SPDX JSON from the extracted source tree (291 packages).
- Prior `main` run: Python 3.11, 3.12, 3.13, Market Hardening, Docker, Formal Verification, Security, Lint, Type Check, Rust, Helm, and lock integrity all passed; only the SBOM source-type mismatch failed.

## Summary by Sourcery

Correct source SBOM generation and validate it in pull requests without broadening SBOM attestation permissions.

Bug Fixes:
- Fix source SBOM generation by scanning an extracted source tree instead of passing an archive as a directory path.

Enhancements:
- Run source SBOM generation for pull requests while restricting SBOM attestations to releases and pushes to main.

CI:
- Expand CI SBOM coverage to pull requests while preserving OIDC-backed attestation only for trusted release and main-push contexts.