### PR TITLE
ci: pin pip for lock integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,8 +411,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - name: Install pip-tools
-        run: pip install pip-tools==7.5.2
+      - name: Install compatible lock tooling
+        # pip-tools 7.5.2 imports an internal API removed by pip 25.3.
+        run: python -m pip install pip==25.2 pip-tools==7.5.2
       - name: Regenerate lock file
         run: pip-compile --generate-hashes --output-file=requirements.lock.new requirements.txt
       - name: Check for drift


### PR DESCRIPTION
## Root cause

PR #109's `Lock File Integrity` job installed `pip-tools==7.5.2` into the mutable runner `pip` environment. The runner resolved pip 25.3, which removed `pip._internal.utils.compat.stdlib_pkgs`; pip-tools 7.5.2 imports that symbol and failed before regenerating the lock.

## Fix

Pin the lock generator environment to `pip==25.2` and `pip-tools==7.5.2`.

## Reproduction

Under Python 3.12, this exact pair regenerates `requirements.lock` byte-for-byte after the workflow's existing normalization of the autogenerated output filename. `actionlint`, Action SHA pin validation, and `git diff --check` pass locally.

No version, package, image, tag, or release publication is included.

## Summary by Sourcery

Pin the lock generation tooling to maintain reliable lock-file integrity checks.

Bug Fixes:
- Pin the lock-file generation workflow to a pip version compatible with pip-tools 7.5.2, preventing lock regeneration failures caused by pip 25.3.

CI:
- Use a dedicated compatible lock-tooling installation in the lock integrity job.