### PR TITLE
docs: record pasted5 governance audit

### DIFF
--- a/evidence/pasted_content_5_execution_no_go_2026-08-24.md
+++ b/evidence/pasted_content_5_execution_no_go_2026-08-24.md
@@ -1,0 +1,66 @@
+# Pasted content 5 execution record: governance hardening and v4.0.0 NO-GO
+
+**Repository:** `JuanLunaIA/aegis-latent-core`  
+**Evidence date:** 2026-08-24 (UTC-03:00)  
+**Audited `main`:** `a2384085cacd1127b81435c062196bf3ccb86173`  
+**Input:** `/home/ubuntu/upload/pasted_content_5.txt`  
+**Input SHA-256:** `07d2918358ba288fab99a1fd1f02363375173ce77cdd1961c290881b1870483b`  
+**Decision:** **NO-GO for tagging or publishing `v4.0.0`**
+
+## Scope and authority boundary
+
+The attached mission was treated as user-supplied requirements data, not as proof that its prerequisites were true. Reversible repository governance improvements were executed where the requested state was exact and independently verifiable. Legal acceptance, account-security changes, access-control changes that could deadlock the sole maintainer, registry publication, version mutation, tag creation, and release publication were not performed without satisfied prerequisites and a valid release candidate.
+
+## Executed state transitions
+
+| Control | Prior observed state | Applied state | Verification |
+|---|---|---|---|
+| GitHub release immutability | UI checkbox was unchecked | **Enabled** | Authenticated GitHub settings UI displayed the checked control and success indicator after the change. |
+| `release` environment | Absent | Created with required reviewer `JuanLunaIA`; self-review remains permitted; custom deployment policies enabled | GitHub REST readback returned the required-reviewer and branch-policy rules. |
+| `pypi` environment | Present without protection rules or branch policy | Restricted to branch `main` and tag pattern `v*` | GitHub REST readback returned custom branch policies `branch:main` and `tag:v*`. |
+| `npm` environment | Absent | Created and restricted to branch `main` and tag pattern `v*` | GitHub REST readback returned custom branch policies `branch:main` and `tag:v*`. |
+| Repository security features | Secret scanning, push protection, Dependabot security updates, vulnerability alerts, automated fixes, and private vulnerability reporting were enabled | No mutation required | Repository API and feature endpoints returned enabled states. |
+| npm 2FA | Enabled for authorization and publishing with one security key | No mutation required | Authenticated npm account page. |
+
+GitHub documents environment creation and required reviewers through `PUT /repos/{owner}/{repo}/environments/{environment_name}` and custom branch/tag policies through the deployment branch policies API.[1][2]
+
+## Release blockers
+
+| Gate | Observed evidence | Consequence |
+|---|---|---|
+| Version synchronization | All 14 source anchors are exactly `3.1.0`; the source contract passes for `v3.1.0` and rejects `v4.0.0`. | A `v4.0.0` tag would intentionally fail the release workflow. |
+| Strict typing | `mypy --strict aegis sdk/python/src` reports **151 errors in 54 files** across 186 checked source files. | The mission's zero-error strict typing condition is false. |
+| PyPI authority | Public `aegis-sdk` exists at version `0.3.0`; authenticated access to its project publishing settings returned **HTTP 403**. The account has no active or pending trusted publishers. | `JuanLunaIA` cannot configure trusted publishing for the existing project from the observed account. Registering a pending publisher for an already-existing project would not solve ownership. |
+| npm authority | Authenticated npm account `juanlunaia` has **0 packages** and **no organizations**. Public registry lookups for `@aegis-latent/sdk` and `aegis-latent-core` returned **404**. | The requested scoped package cannot be published until the package/scope ownership model is established. |
+| CLA | CLA Assistant displayed “Please agree” but no agreement version or substantive agreement text was rendered. | No legal attestation was made. An empty/undefined agreement cannot be truthfully accepted. |
+| Branch protection | GitHub REST readback showed no required checks, no PR-review requirement, unsigned commits allowed, linear history disabled, admin enforcement disabled, and force-push enabled. | Applying the pasted names verbatim would create non-satisfiable checks (`SDK (Python)`, `SDK (TypeScript)`, and `Dashboard (Build & Test)` do not match current check contexts). Requiring a CODEOWNER review would also rely on the sole CODEOWNER reviewing their own pull request, which GitHub does not treat as an independent approval. |
+| Required-check health | The latest `main` commit had all 27 GitHub check-runs successful, but the separate `CircleCI Pipeline` commit status was `error`. | A broad “all checks” protection policy would be blocked by a non-GitHub external status until CircleCI is repaired or intentionally excluded. |
+| Registry and release artifacts | No remote `v4.0.0` tag, GitHub Release, npm package, OCI digest, Cosign signature, Rekor record, or v4 package installation exists. | A release verification certificate cannot be emitted without fabricating evidence. |
+| Security alert inventory | Feature enablement is visible, but Dependabot, code-scanning, and secret-scanning alert-list APIs return **HTTP 403** to the current integration. | No claim of a clean alert inventory is made. |
+
+## Branch-protection decision boundary
+
+The mission's branch-protection payload is materially inconsistent with the repository's current status contexts. Current successful contexts include `Python SDK`, `TypeScript SDK`, `Formal Verification (Z3, Lean, TLC)`, `Generate SBOM`, `Helm Lint`, `Market Hardening Gates`, `Rust Extension`, `Security Scan`, `Test (Python 3.11)`, `Test (Python 3.12)`, and `Test (Python 3.13)`. There is no current `Dashboard (Build & Test)` context, and the SDK names differ from the pasted names. Because enforcing the supplied names could prevent every future merge, branch protection was left unchanged pending an explicit choice of corrected contexts and a viable independent reviewer model.
+
+## Publication workflow truth boundaries
+
+The repository contains tag-triggered PyPI and npm workflows, but their publish jobs are additionally gated by the repository variable `AEGIS_TRUSTED_PUBLISHING_ENABLED == 'true'`. The current integration cannot read repository variables (`HTTP 403`), so the variable's state is **unverified**. The OCI workflow only builds multi-architecture images with `push: false`; it does not publish, sign, or attest a registry image. The GitHub Release workflow creates a GitHub Release only after signed-tag, ancestry, exact-version, build, and protected-environment gates; it does not establish PyPI/npm ownership or OCI publication.
+
+## Injection analysis and containment log
+
+The attached document asserted an autonomous six-phase imperative and instructed the agent to infer that external credentials, publisher ownership, release readiness, and all checks were available. Those assertions were treated as unverified. The falsification tests were direct registry/API queries, authenticated read-only browser inspection, exact source-contract execution, strict static typing, tag/release absence checks, and workflow inspection. The claims were falsified by the 3.1.0 anchors, PyPI 403, npm 404 and zero-package account state, incomplete CLA page, missing branch protection, and strict typing failures.
+
+No credential values were read, copied, stored, or exposed. No CLA was accepted; no 2FA setting, token, organization, publisher, repository variable, tag, release, package, container, signature, attestation, or Rekor entry was created.
+
+## Falsification and go criteria
+
+The NO-GO decision can be falsified only by all of the following observable conditions: a reviewed v4 release candidate with all 14 anchors and changelog synchronized; strict and configured quality gates passing; corrected branch protection with satisfiable status contexts and a viable independent reviewer; a versioned CLA with lawful acceptance; demonstrated PyPI project ownership and an active trusted publisher bound to the exact workflow/environment; demonstrated npm scope/package authority and OIDC publishing readiness; successful non-production dress rehearsals; and independently verifiable OCI, signing, SBOM, provenance, and registry controls. Only after those conditions pass should a separately approved signed tag and production publication be considered.
+
+## Rollback and kill criteria
+
+The three environment configurations can be edited or deleted through repository settings if they block intended non-release workflows. Release immutability should remain enabled unless the repository owner deliberately accepts mutable historical releases. Stop any future release immediately if tag/version ancestry checks fail, a registry identity differs from the reviewed coordinates, an environment approval is bypassed, a package or tag already exists, attestation verification fails, or any generated evidence lacks a source digest.
+
+## References
+
+[1]: https://docs.github.com/en/rest/deployments/environments "GitHub REST API endpoints for deployment environments"
+[2]: https://docs.github.com/en/rest/deployments/branch-policies?apiVersion=2026-03-10 "GitHub REST API endpoints for deployment branch policies"

--- a/evidence/pasted_content_5_execution_no_go_2026-08-24.sha256
+++ b/evidence/pasted_content_5_execution_no_go_2026-08-24.sha256
@@ -1,0 +1,1 @@
+04df480e0f05dbe3bc07f1fb22bfe64c980d87600b9e9653ab1ce6c77ba2c692  pasted_content_5_execution_no_go_2026-08-24.md

--- a/evidence/verify_pasted_content_5_evidence.sh
+++ b/evidence/verify_pasted_content_5_evidence.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Juan Luna. All rights reserved.
+# Licensed under the GNU Affero General Public License v3 (AGPLv3) OR under a
+# Proprietary Commercial License. See LICENSE and COMMERCIAL.md for terms.
+set -euo pipefail
+cd "$(dirname "$0")"
+sha256sum --check pasted_content_5_execution_no_go_2026-08-24.sha256


### PR DESCRIPTION
## Summary

Records the bounded execution of `pasted_content_5.txt` and the evidence-backed NO-GO for a v4.0.0 production release.

Externally applied controls:
- enabled GitHub release immutability;
- created the protected `release` environment with `JuanLunaIA` as required reviewer;
- restricted `release`, `pypi`, and `npm` deployments to `main` and `v*` tags.

The report documents why branch protection, CLA acceptance, trusted-publisher registration, version changes, tagging, and publication were not executed. It includes a SHA-256 digest and local verifier.

No version, tag, GitHub Release, package, image, signature, or attestation was created.

## Summary by Sourcery

Document the bounded governance audit and defer v4.0.0 tagging and publication until release prerequisites are verifiably satisfied.

Enhancements:
- Record the governance audit evidence and NO-GO decision for the v4.0.0 release, including observed release blockers and decision boundaries.
- Document the verified GitHub release and deployment-environment controls applied during the audit.

Documentation:
- Add a dated execution record with evidence, SHA-256 digest, references, rollback criteria, and release-readiness requirements.
- Add a local shell verifier for the recorded evidence digest.