### PR TITLE
fix: provision Python for signed tag workflow

### DIFF
--- a/.aegis_ai_context/MANIFEST.json
+++ b/.aegis_ai_context/MANIFEST.json
@@ -327,8 +327,8 @@
     {
       "category": "governed_input",
       "path": ".github/workflows/create_release_tag.yml",
-      "sha256": "c850e98e51d2cf803c824fb08730a903e254c648f2a56772e8f1d8545afff9d1",
-      "size": 2958
+      "sha256": "4778ad8dbb8434dbbb2ffab5a236c2d9a95c14d0e80fc407cd6c261894f3dfbb",
+      "size": 3087
     },
     {
       "category": "governed_input",
@@ -465,8 +465,8 @@
     {
       "category": "governed_input",
       "path": "scripts/verify_release_contract.py",
-      "sha256": "96e0e6511a887b939e8181d83d83f1d8d4909ff53492c83132bf1f4d61d5b02c",
-      "size": 38755
+      "sha256": "cac40c520ffea00380de879b719d90a1bb923db283f3949e68faa5a6ce49ae6f",
+      "size": 38918
     },
     {
       "category": "governed_input",

--- a/.github/workflows/create_release_tag.yml
+++ b/.github/workflows/create_release_tag.yml
@@ -26,6 +26,10 @@ jobs:
           fetch-depth: 0
           ref: main
 
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
       - name: Verify exact protected main release candidate
         run: |
           set -euo pipefail

--- a/scripts/verify_release_contract.py
+++ b/scripts/verify_release_contract.py
@@ -657,6 +657,9 @@ def _validate_release_tag_workflow(root: Path, diagnostics: list[Diagnostic]) ->
         "tag-workflow.dispatch-only": _has_dispatch_only_trigger(workflow),
         "tag-workflow.environment": re.search(r"(?m)^    environment:\s*$", job) is not None
         and re.search(r"(?m)^      name:\s*release\s*$", job) is not None,
+        "tag-workflow.python-runtime": "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1"
+        in job
+        and 'python-version: "3.12"' in job,
         "tag-workflow.permissions": top_permissions == [{"contents": "read"}]
         and job_permissions == [{"actions": "write", "contents": "write", "id-token": "write"}],
         "tag-workflow.exact-main": "ref: main" in job

--- a/tests/test_release_contract_v4.py
+++ b/tests/test_release_contract_v4.py
@@ -414,6 +414,12 @@ def test_release_contract_binds_package_identity_and_rust_runtime_version(
             'echo "tags=${IMAGE}:${VERSION},${IMAGE}:sha-${GITHUB_SHA},${IMAGE}:latest"',
             "oci.immutable-tags",
         ),
+        (
+            "create_release_tag.yml",
+            'python-version: "3.12"',
+            'python-version: "3.10"',
+            "tag-workflow.python-runtime",
+        ),
     ],
 )
 def test_contract_rejects_unreachable_or_alternate_publication_paths(


### PR DESCRIPTION
## Failure evidence

The first protected `Create signed release tag` run ([33051972190](https://github.com/JuanLunaIA/aegis-latent-core/actions/runs/33051972190)) failed before tag creation in the version-derivation step because the `ubuntu-22.04` default `python` was Python 3.10 and therefore lacked `tomllib`. External readback confirmed that neither `v4.0.2` nor a GitHub Release was created and no publication workflow was dispatched.

## Fix

This hotfix provisions Python 3.12 through the repository's already-pinned `actions/setup-python` commit before parsing `pyproject.toml`. The release contract now requires that exact runtime and the mutation suite rejects regressions.

## Validation

The v4.0.2 release contract is READY; all 14 anchors remain synchronized. AI context manifest verification (83 governed files), 43 focused contract/context tests, Ruff, workflow YAML/SHA-pin validation, deployment YAML validation, and `git diff --check` all pass.

## Summary by Sourcery

Provision the required Python runtime for signed release tag creation and enforce it through the release contract.

Bug Fixes:
- Ensure the signed release tag workflow uses Python 3.12 before deriving the release version, restoring access to the required TOML parsing support.

Enhancements:
- Extend the release contract and regression tests to require the pinned Python setup action and Python 3.12 runtime.

Tests:
- Update governed-input manifest checksums for the workflow and release contract validator.