### PR TITLE
docs: cut README hedging, add Docker quickstart and storage requirements

### DIFF
--- a/.aegis_ai_context/MANIFEST.json
+++ b/.aegis_ai_context/MANIFEST.json
@@ -99,8 +99,8 @@
     {
       "category": "governed_input",
       "path": "README.md",
-      "sha256": "4b05478b416fab8271aa96db629dbd345d2c378619287246911e09306f486273",
-      "size": 38302
+      "sha256": "07cf7d11059a4c3185e3aa354d6130f3db7c5c2c32f5a610e87503a7adac7d3f",
+      "size": 33566
     },
     {
       "category": "governed_input",

--- a/README.md
+++ b/README.md
@@ -29,37 +29,16 @@
 
 [**🚀 Local quickstart**](#4-quickstart-for-local-evaluation) · [**🏛️ Architecture**](#5-request-and-evidence-lifecycle) · [**📦 SDKs**](#sdk-registry-and-source-verification) · [**📊 Dashboard**](#6-forensic-audit-dashboard) · [**📑 Enterprise pilot**](#8-commercial-path)
 
-> **Version boundary:** The checked-out source baseline/release target is **`4.0.2`** with fourteen synchronized anchors. Source metadata does not establish external lifecycle state; verify the `v4.0.2` tag, GitHub Release, PyPI and npm artifacts, OCI digest, signature, and attestation through independent readback. Historically, public label `v4.0.1` is a lightweight tag targeting `6469904380218584ae0b5221334bc9a46500f5ba`; its tag-triggered workflows failed, and observed `4.0.0` registry objects have no attributed provenance from those workflows.
+Aegis sits between your application and your model provider. Every governed call gets a signed, hash-linked evidence record committed before the response returns — and a portable inclusion proof your client can verify on its own.
 
-## 2. Version and epistemic boundaries
-
-> [!NOTE]
-> **Version status.** The repository source and release candidate is `4.0.2`; fourteen release-contract anchors are synchronized at that version. Its immutable parent/source comparison, `fdace8844568eb788216740b2cb5daf187d99d3b`, has fourteen `4.0.0` anchors. The prior public GitHub baseline remains label `v4.0.1`, a lightweight tag targeting `6469904380218584ae0b5221334bc9a46500f5ba`, with failed tag-triggered workflows. PyPI and npm were separately observed at `aegis-latent-sdk` version `4.0.0`, but provenance is not attributed to those failed runs. External `v4.0.2` publication must be established by post-publication readback; source metadata alone does not establish it.
+## 2. Status
 
 > [!NOTE]
-> **Release-envelope readback, 2026-09-01.** A read-only GitHub API readback recorded the following and does not by itself establish registry availability, artifact integrity, or acceptance: the `v4.0.2` GitHub Release exists as a non-draft, non-prerelease entry carrying **31 assets** — `SHA256SUMS`, `release-asset-manifest.json`, two SPDX SBOMs, Python core and SDK wheels plus sdists, the TypeScript tarball, seven `aegis_rust` platform wheels, and a `.sha256` sidecar for each artifact. The annotated tag `v4.0.2` resolves to commit `a6eb58dcc03f8b638c8f3e35f0300f5443a926ca` and carries a Sigstore keyless signature whose certificate identity is the repository's `create_release_tag.yml@refs/heads/main` workflow under issuer `token.actions.githubusercontent.com`.
->
-> Three limits apply to that readback and must travel with it. GitHub's native signature check reports the tag as unverified with reason `bad_cert`, which is the expected presentation for short-lived Sigstore certificates and means trust requires `gitsign` or `cosign` validation against the transparency log rather than the GitHub badge. Asset bytes were not downloaded, so `SHA256SUMS` was not checked and no artifact digest was confirmed. PyPI and npm remain observed at `4.0.0`, so the presence of assets in a release envelope is not registry publication.
+> **Current release candidate:** `v4.0.2` (source, fourteen synchronized anchors). **Registries:** `aegis-latent-sdk` observed at `4.0.0`. The gateway ships from source; the registries carry the SDKs only. Provenance, signature verification, and why GitHub shows the tag as `bad_cert` are covered in [Release Status](docs/RELEASE_STATUS.md).
 
-> [!IMPORTANT]
-> **Product boundary.** Aegis is an AI Governance and Evidence Gateway. It can implement tested technical controls and produce structured cryptographic evidence under declared conditions; it is not an LLM, a universal WAF, a compliance certification, a legal-admissibility ruling, a production SLO, or a substitute for network, identity, privacy, retention, incident-response, and deployment controls. Regulatory mappings describe possible technical contributions only and require customer-specific legal, organizational, and technical assessment.
-
-Public claims use distinct evidence states:
-
-| State | Meaning |
-|---|---|
-| **Implemented** | Source and regression tests establish behavior within stated conditions. |
-| **Measured** | A named workload, revision, environment, date, and retained artifact establish a bounded result. |
-| **Configuration-dependent** | The control requires validation in the target deployment. |
-| **Roadmap** | The capability is incomplete or unmeasured and must not be described as available. |
-| **Legal-review-required** | Regulatory, certification, procurement, contractual, and admissibility conclusions remain outside repository evidence. |
-
-Publication does not by itself prove a signed-tag trust path, successful automated provenance workflow, production acceptance, or independent assurance. The controlling references are the [Public Claims Matrix](docs/CLAIMS_MATRIX.md) and [Unsupported Claims Report](docs/institutional/UNSUPPORTED_CLAIMS.md).
+Aegis applies request policy to LLM traffic and commits a signed, hash-linked record of every governed interaction before the response returns. It is a governance and evidence layer — not a model, a WAF, a certification, or a legal ruling. Boundaries are consolidated in [Boundaries](docs/BOUNDARIES.md); [`docs/CLAIMS_MATRIX.md`](docs/CLAIMS_MATRIX.md) controls public claims.
 
 ## 3. Four technical pillars
-
-> [!NOTE]
-> These pillars describe the checked-out `v4.0.2` source baseline/release target. Its fourteen synchronized anchors do not establish external publication or acceptance for a target deployment. The immutable parent comparison `fdace8844568eb788216740b2cb5daf187d99d3b` retains fourteen `4.0.0` anchors.
 
 | Pillar | What the merged source implements | Evidence boundary |
 |---|---|---|
@@ -70,7 +49,36 @@ Publication does not by itself prove a signed-tag trust path, successful automat
 
 ## 4. Quickstart for local evaluation
 
-The local profile is for development, tests, and evidence replay, not production deployment. Python 3.11 or later is required. Use a pinned checkout to evaluate the complete gateway; the public registries contain the SDKs only.
+The local profile is for development, tests, and evidence replay — not a deployment configuration. The gateway runs from source; the registries carry the SDKs only.
+
+### Option A — Docker
+
+Point it at any OpenAI-compatible upstream and bring it up:
+
+```bash
+git clone https://github.com/JuanLunaIA/aegis-latent-core.git
+cd aegis-latent-core
+export AEGIS_BACKEND_URL="https://api.openai.com/v1"
+export AEGIS_BACKEND_API_KEY="sk-your-upstream-key"
+docker compose up
+```
+
+Check it is live, then send a governed call through it:
+
+```bash
+curl -s http://127.0.0.1:8080/health
+
+curl -s http://127.0.0.1:8080/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"hello"}]}' \
+  -D - -o /dev/null | grep -i '^x-aegis'
+```
+
+The `x-aegis-*` response headers carry the evidence status and the proof link for that call. Evidence persists in the `aegis-evidence` volume. The root [`docker-compose.yml`](docker-compose.yml) runs development enforcement with authentication disabled; for a hardened profile that fails closed when secrets are absent, use [`deploy/docker/docker-compose.yml`](deploy/docker/docker-compose.yml).
+
+### Option B — From source
+
+Python 3.11 or later is required.
 
 ```bash
 git clone https://github.com/JuanLunaIA/aegis-latent-core.git
@@ -95,25 +103,17 @@ export AEGIS_WAL_PATH='/tmp/aegis-evaluation.wal.jsonl'
 aegis
 ```
 
-There is no `aegis --dev` option. API calls require the configured upstream to be running. The gateway smoke test does not prove provider compatibility, production acceptance, or a production security posture. Do not commit provider keys, gateway bearer tokens, signing secrets, WAL records, or customer payloads. See the [developer quickstart](docs/DEVELOPER_QUICKSTART.md) and [deployment guide](DEPLOYMENT_GUIDE.md) for the complete source-development and deployment gates.
+There is no `aegis --dev` shortcut, and calls require your upstream to be running. Never commit provider keys, gateway tokens, signing secrets, WAL records, or payloads. For hardening and deployment gates, see the [developer quickstart](docs/DEVELOPER_QUICKSTART.md) and [deployment guide](DEPLOYMENT_GUIDE.md).
 
-### SDK registry and source verification
+### Python SDK
 
-The current SDK source version is `4.0.2`; the Python import namespace is `aegis_sdk` and both distributions use the unscoped name `aegis-latent-sdk`. PyPI and npm were last observed at `4.0.0`, without attributed provenance from the failed `v4.0.1` tag workflows. Do not assume `4.0.2` is available from either registry until successful publication and registry readback.
-
-### Python SDK from the source tree
-
-After PyPI successfully publishes and readback confirms version `4.0.2`, install the OpenAI-enabled package with:
-
-```bash
-python -m pip install 'aegis-latent-sdk[openai]==4.0.2'
-```
-
-Until that readback succeeds, install the candidate from a pinned source checkout:
+Install from the source tree you just cloned:
 
 ```bash
 python -m pip install './sdk/python[openai]'
 ```
+
+The published package is named `aegis-latent-sdk` on both registries; the Python import namespace is `aegis_sdk`. Registries currently serve `4.0.0` — see [Release Status](docs/RELEASE_STATUS.md) before pinning a registry version.
 
 The wrapper subclasses the official OpenAI client and preserves its native resource and response types within the declared and tested dependency range:
 
@@ -135,15 +135,9 @@ response = client.chat.completions.create(
 
 The SDK also provides `Anthropic`, `AsyncOpenAI`, and `AsyncAnthropic`. Native Anthropic Messages calls require the gateway itself to run with `AEGIS_PROVIDER=anthropic`. Model availability remains upstream-dependent.
 
-### TypeScript SDK from the source tree
+### TypeScript SDK
 
-After npm successfully publishes and readback confirms version `4.0.2`, install it with the OpenAI peer dependency:
-
-```bash
-npm install aegis-latent-sdk@4.0.2 openai@^6.49.0
-```
-
-Until that readback succeeds, build and install the candidate from a pinned source checkout:
+Build and install from the source tree, with `openai` as a peer dependency:
 
 ```bash
 npm --prefix sdk/typescript ci
@@ -168,11 +162,9 @@ const response = await client.chat.completions.create({
 });
 ```
 
-Both SDKs leave proof verification disabled by default. Enabling `verify_proof` or `verifyProof` also requires an independently provisioned `trusted_mmr_root` or `trustedMmrRoot` containing exactly 64 lowercase hexadecimal characters. A root copied from the same untrusted response is not an independent trust anchor, and an initial `pending-terminal` streaming response is not a terminal inclusion proof. Compatibility is limited to tested routes, behaviors, and dependency ranges; these integrations are not universal replacements for every provider endpoint. For source verification, use the component commands in the [integration guide](docs/DEVELOPER_INTEGRATIONS_GUIDE.md).
+Proof verification is off by default. Enabling `verify_proof` (Python) or `verifyProof` (TypeScript) requires an independently provisioned `trusted_mmr_root` / `trustedMmrRoot` — 64 lowercase hex characters, pinned through a channel other than the response being verified. Streaming responses start `pending-terminal`; fetch the proof after the terminal marker. Details in the [integration guide](docs/DEVELOPER_INTEGRATIONS_GUIDE.md).
 
 ## 5. Request and evidence lifecycle
-
-> **Baseline boundary:** The sequence below describes the checked-out `v4.0.2` source baseline/release target. Confirm the exact reviewed commit before deployment; source version metadata does not establish an external `v4.0.2` publication.
 
 ```mermaid
 sequenceDiagram
@@ -262,9 +254,7 @@ External laws, standards, and guidance can change. Qualified counsel or an asses
 
 ## 8. Commercial path
 
-> **Commercial boundary.** The checked-out source baseline/release target is `4.0.2`; source metadata does not establish external lifecycle state; verify the tag, GitHub Release, PyPI, npm, OCI digest, signature, and attestation through independent readback. The historical public `v4.0.1` label and observed `4.0.0` registry objects remain distinct baselines. Any evaluation, quote, acceptance plan, and evidence package must identify the exact commit and artifact versions rather than relying on the release label alone.
-
-Aegis is distributed under the terms in [`LICENSE`](LICENSE). A separate commercial agreement may be available for organizations that require terms different from the AGPLv3, but only an executed agreement defines licensing, support, warranty, redistribution, and other contractual rights. [`COMMERCIAL.md`](COMMERCIAL.md) is a procurement summary, not legal advice or an automatic AGPL exemption.
+Aegis is distributed under [`LICENSE`](LICENSE) (AGPLv3). A separate commercial agreement may be available for organizations that need terms different from the AGPLv3; only an executed agreement defines licensing, support, warranty, and redistribution rights. [`COMMERCIAL.md`](COMMERCIAL.md) is a procurement summary, not legal advice or an automatic AGPL exemption.
 
 | Package | Directional scope | Commercial boundary |
 |---|---|---|
@@ -274,15 +264,13 @@ Aegis is distributed under the terms in [`LICENSE`](LICENSE). A separate commerc
 | **Enterprise** | Multiple environments or procurement-heavy deployment, with architecture and security-review assistance plus negotiated response targets | Requires accountable staffing, an operating support model, legal terms, data-handling boundaries, and explicit exclusions. |
 | **Sovereign / OEM** | Air-gapped, embedded, redistribution, escrow, or dedicated-assurance requirements | Future/custom only; not a default offer or present assurance commitment. |
 
-The retained planning ranges—**USD 10,000–30,000** for a **4–8 week Team/Pilot**, **USD 40,000–100,000 annually** for Production, and **USD 100,000–250,000+ annually** for Enterprise—are **internal hypotheses to validate**. They are **not public list prices, observed contract values, valuations, or binding offers**. A defensible quote requires the target topology, environments, request volume, providers, streaming profile, retention and residency needs, storage and key custody, support hours, escalation path, security-review scope, geography, and legal entity.
+No prices are published here. Planning ranges, packaging hypotheses, and the unit-economics model live in [`docs/COMMERCIAL_STRATEGY_US.md`](docs/COMMERCIAL_STRATEGY_US.md). They are internal hypotheses pending validation, not list prices or observed contract values.
 
-A pilot should use the buyer's actual workload and produce a customer-owned report. Its declared acceptance plan should cover request/response evidence correlation, upstream failure, Redis/rate-limit failure, WAL replay and integrity, key rotation, the pinned WAF corpus, rollback, and the target ingress, storage, secret manager, and container profile. The report should record workload and volume, environment, rejected traffic, evidence completeness, failures, support hours, exclusions, and residual risk. Passing a pilot does not establish certification, regulatory compliance, production SLOs, or legal admissibility.
-
-See [`docs/COMMERCIAL_STRATEGY_US.md`](docs/COMMERCIAL_STRATEGY_US.md) for the packaging hypothesis, [`docs/BUYER_GUIDE_US.md`](docs/BUYER_GUIDE_US.md) for pilot acceptance and procurement blockers, and [`docs/FAQ_PROCUREMENT.md`](docs/FAQ_PROCUREMENT.md) for licensing, pricing, support, and assurance boundaries.
+Run a pilot on your own workload and keep the report. [`docs/BUYER_GUIDE_US.md`](docs/BUYER_GUIDE_US.md) has the acceptance criteria and the procurement blockers to clear first; [`docs/FAQ_PROCUREMENT.md`](docs/FAQ_PROCUREMENT.md) covers licensing, support, and assurance.
 
 ## Related documents — 9. Audience navigation
 
-The checked-out source baseline/release target is **4.0.2** with fourteen synchronized anchors. The prior public **v4.0.1** label targets `6469904380218584ae0b5221334bc9a46500f5ba`; observed registry packages remain **4.0.0** and are not attributed to its failed workflows. Use each document's declared baseline and boundaries. Publication does not establish production acceptance, certification, or legal conclusions.
+Each document declares its own baseline and boundaries.
 
 | Audience | Start here | Scope boundary |
 |---|---|---|
@@ -294,7 +282,7 @@ The checked-out source baseline/release target is **4.0.2** with fourteen synchr
 ## 10. Verified metrics, repository map and integrity
 
 > [!NOTE]
-> **Metric scope matters.** The checked-out source baseline/release target is `4.0.2`; source metadata does not establish external lifecycle state; verify the tag, GitHub Release, PyPI, npm, OCI digest, signature, and attestation through independent readback. The historical public `v4.0.1` label and observed `4.0.0` registry objects are separate from the dated candidate evidence below. Candidate figures below come from the retained **2026-08-24** source-candidate gate for commit `2050a310ec295afc61d033ff842c9a535a4f3105`, unless a row says otherwise. Publication-gate documentation was audited on **2026-08-25** at `6469904380218584ae0b5221334bc9a46500f5ba`. These results are regression evidence for named revisions and environments, not production capacity, an SLO, certification, or a legal conclusion.
+> **Metric scope.** Candidate figures come from the retained **2026-08-24** source-candidate gate at commit `2050a310ec295afc61d033ff842c9a535a4f3105`, unless a row says otherwise. These are regression results for named revisions and environments — not capacity, an SLO, certification, or a legal conclusion.
 
 ### Verified metrics
 
@@ -330,12 +318,27 @@ Historical performance and security measurements remain attached to the publishe
 | [`docs/CLAIMS_MATRIX.md`](docs/CLAIMS_MATRIX.md) | Public-claim status, evidence locators, boundaries, and falsification rules. |
 | [`evidence/INDEX.md`](evidence/INDEX.md) | Entry point for retained historical and source-readiness evidence. |
 
-### Integrity and project links
+## 11. Community and contributing
 
-- **Release:** Source baseline/release target `4.0.2` has fourteen synchronized anchors, while source metadata does not establish external lifecycle state; verify the tag, GitHub Release, PyPI, npm, OCI digest, signature, and attestation through independent readback. Historically, `v4.0.1` is a lightweight tag targeting `6469904380218584ae0b5221334bc9a46500f5ba` whose tag workflows failed; registries were observed at `4.0.0` without attributed provenance.
-- **Security:** Follow [`SECURITY.md`](SECURITY.md) for supported reporting channels and scope.
-- **Contributing:** See [`CONTRIBUTING.md`](CONTRIBUTING.md).
-- **License:** Use is governed by [`LICENSE`](LICENSE) and, where applicable, [`COMMERCIAL.md`](COMMERCIAL.md). This README is not legal advice.
-- **Repository:** [JuanLunaIA/aegis-latent-core](https://github.com/JuanLunaIA/aegis-latent-core) · [Releases](https://github.com/JuanLunaIA/aegis-latent-core/releases) · [Issues](https://github.com/JuanLunaIA/aegis-latent-core/issues)
+Aegis is built in the open. If you find a gap in the evidence chain, we want to know about it.
 
-Aegis supplies software controls and bounded technical evidence. Deployment acceptance, regulatory applicability, compliance determinations, storage immutability, signer trust, and legal admissibility remain the responsibility of the deploying organization and its qualified reviewers.
+- **Issues and feature requests:** [GitHub Issues](https://github.com/JuanLunaIA/aegis-latent-core/issues)
+- **Security reports:** [`SECURITY.md`](SECURITY.md) — please use the private advisory channel, not a public issue
+- **Contributing:** [`CONTRIBUTING.md`](CONTRIBUTING.md) covers the dev setup, the test commands, and the PR checklist
+- **Release provenance:** [`docs/RELEASE_STATUS.md`](docs/RELEASE_STATUS.md) · [Releases](https://github.com/JuanLunaIA/aegis-latent-core/releases)
+- **License:** [`LICENSE`](LICENSE) (AGPLv3). Alternative terms: [`COMMERCIAL.md`](COMMERCIAL.md)
+
+## 12. Boundaries and limitations
+
+Aegis provides technical controls and cryptographic evidence. It is not a model, a WAF, a compliance certification, a legal ruling, or a service level objective. The following are the limits worth knowing before you deploy; each links to the detail.
+
+- **Durability is a hardware property.** A returned `fsync` means the kernel was asked to flush, not that bytes survived a power cut. Substrate requirements: [storage requirements](docs/operations/STORAGE_REQUIREMENTS.md).
+- **Proofs are relative to a trusted root.** Inclusion is proven against a root you pin independently — not authorship, time, ordering, or external immutability. See [boundaries](docs/BOUNDARIES.md).
+- **The default signer is symmetric.** HMAC detects modification by anyone without the key; it is not third-party non-repudiation.
+- **Redaction is deterministic pattern matching.** It settles supported identifier grammars across chunk boundaries. It is not the complete HIPAA Safe Harbor method and does not catch every encoding or paraphrase.
+- **Formal artifacts verify models, not runtimes.** Z3, Lean, and TLC check stated formulas and bounded abstractions, not the Python or Rust runtime or the FFI boundary.
+- **Topology decides evidence semantics.** One writer per log path. Multiple workers sharing a path do not produce one ordered chain — see [architecture](docs/institutional/DOC-01_ENTERPRISE_ARCHITECTURE.md) §8.
+- **Regulatory applicability is yours.** Mappings are technical contributions; scope, retention, custody, and admissibility belong to your organization and its reviewers.
+- **Out of the threat model by design:** physical attacks, hypervisor or host-root compromise, side channels, guaranteed prevention of prompt injection, and network-layer denial of service. See [threat model](docs/security/THREAT_MODEL.md).
+
+Full claim register: [`docs/CLAIMS_MATRIX.md`](docs/CLAIMS_MATRIX.md). Consolidated boundaries: [`docs/BOUNDARIES.md`](docs/BOUNDARIES.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+# Aegis Latent Core — local evaluation profile.
+#
+# This file is for evaluating the gateway on your own machine. It runs in
+# development enforcement mode with authentication disabled, which is NOT a
+# deployment configuration. For a hardened deployment that fails closed when
+# secrets are absent, use deploy/docker/docker-compose.yml instead.
+#
+# Usage:
+#   export AEGIS_BACKEND_URL="https://api.openai.com/v1"   # your upstream
+#   export AEGIS_BACKEND_API_KEY="sk-..."                  # upstream credential
+#   docker compose up
+#
+# Then send a request:
+#   curl -s http://127.0.0.1:8080/health
+#
+# Evidence is written to the named volume `aegis-evidence` and survives
+# `docker compose down`. Remove it with `docker compose down -v`.
+
+services:
+  aegis:
+    build:
+      context: .
+      dockerfile: deploy/docker/Dockerfile
+    image: aegis-latent-core:eval
+    restart: unless-stopped
+    ports:
+      - "${AEGIS_PORT:-8080}:8080"
+    environment:
+      # Evaluation posture. Never use these values for governed traffic.
+      AEGIS_SECURITY_ENFORCEMENT_MODE: development
+      AEGIS_DEBUG_MODE: "true"
+      AEGIS_AUTH_DISABLED: "true"
+      # Upstream provider. Required: compose fails fast if unset.
+      AEGIS_BACKEND_URL: ${AEGIS_BACKEND_URL:?set AEGIS_BACKEND_URL to your OpenAI-compatible upstream, e.g. https://api.openai.com/v1}
+      AEGIS_BACKEND_API_KEY: ${AEGIS_BACKEND_API_KEY:-}
+      # Evidence path inside the container, backed by the named volume below.
+      AEGIS_WAL_PATH: /data/aegis.wal.jsonl
+      AEGIS_HOST: 0.0.0.0
+      AEGIS_PORT: "8080"
+    volumes:
+      - aegis-evidence:/data
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/health', timeout=3).status == 200 else 1)",
+        ]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+volumes:
+  aegis-evidence:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,12 +24,27 @@ services:
     image: aegis-latent-core:eval
     restart: unless-stopped
     ports:
-      - "${AEGIS_PORT:-8080}:8080"
+      # Bound to loopback: this profile disables authentication, so it must not
+      # be reachable from the network. Override only on an isolated host.
+      - "127.0.0.1:${AEGIS_PORT:-8080}:8080"
     environment:
       # Evaluation posture. Never use these values for governed traffic.
       AEGIS_SECURITY_ENFORCEMENT_MODE: development
       AEGIS_DEBUG_MODE: "true"
       AEGIS_AUTH_DISABLED: "true"
+      # The image sets a strict deployment posture in its own ENV block
+      # (deploy/docker/Dockerfile). Compose inherits those values, so every one
+      # that needs infrastructure this profile does not run is overridden here.
+      #
+      # Without this override the image's AEGIS_RATE_LIMIT_BACKEND=redis is
+      # inherited, RedisRateLimitBackend is constructed with an empty
+      # AEGIS_REDIS_URL, and startup fails with "redis_url must not be empty".
+      AEGIS_RATE_LIMIT_BACKEND: memory
+      # These three are only enforced when the mode is strict, but they are
+      # pinned explicitly so this profile does not depend on that coupling.
+      AEGIS_REQUIRE_DURABLE_EVIDENCE: "false"
+      AEGIS_REQUIRE_LSM: "false"
+      AEGIS_REQUIRE_SECCOMP: "false"
       # Upstream provider. Required: compose fails fast if unset.
       AEGIS_BACKEND_URL: ${AEGIS_BACKEND_URL:?set AEGIS_BACKEND_URL to your OpenAI-compatible upstream, e.g. https://api.openai.com/v1}
       AEGIS_BACKEND_API_KEY: ${AEGIS_BACKEND_API_KEY:-}

--- a/docs/BOUNDARIES.md
+++ b/docs/BOUNDARIES.md
@@ -1,0 +1,62 @@
+# Product and Evidence Boundaries
+
+**Last verified:** 2026-09-01 UTC
+**Release baseline:** checked-out source baseline/release target `4.0.2` with fourteen synchronized anchors
+
+This document consolidates the boundary statements that apply across Aegis. It exists so that `README.md` and the developer guides can describe mechanisms plainly and link here once, instead of repeating a disclaimer beside every sentence.
+
+Nothing here weakens a claim made elsewhere. Where this document and marketing copy disagree, this document and [`CLAIMS_MATRIX.md`](CLAIMS_MATRIX.md) control.
+
+## What Aegis is
+
+An OpenAI-compatible governance and evidence gateway. It sits between an application and an upstream model provider, applies configured request policy, and commits a signed, hash-linked record of governed interactions before returning a response.
+
+## What Aegis is not
+
+It is not a model, a universal web application firewall, a compliance certification, a legal-admissibility determination, a service level objective, or a replacement for network, identity, privacy, retention, or incident-response controls in the deploying organization.
+
+## Evidence boundaries
+
+| Mechanism | What it establishes | What it leaves open |
+|---|---|---|
+| Durable commit before response | The evidence record was written, flushed, and synchronized through the configured path before the response returned | `fsync` returning means the process asked the kernel to flush. Survival of a power cut is a property of the device, controller, and filesystem. See [storage requirements](operations/STORAGE_REQUIREMENTS.md). |
+| Hash chain and signature | Modification of a committed record is detectable without the signing key | The signer is symmetric HMAC by default. A holder of that key can rewrite history consistently. Third-party non-repudiation requires an asymmetric signer and external key custody. |
+| Portable MMR inclusion proof | A disclosed leaf is included under a root the verifier already trusts | It does not establish authorship, time, custody, ordering across processes, external immutability, or that the trusted root is authentic. The root must be pinned through an independent channel. |
+| Streaming terminal summary | Exactly one summary covering the exact emitted bytes was committed before the terminal marker | Initial stream headers are `pending-terminal` and carry no proof. Per-stream bounds are enforced; aggregate memory scales with concurrency and needs deployment-level admission control. |
+| Formal artifacts | The stated formulas and bounded models hold under their declared assumptions | They are abstractions, not refinement proofs of the Python runtime, the Rust runtime, the FFI boundary, the filesystem, or any deployment. |
+| Streaming de-identification | Supported bounded identifier grammars are settled before release, including across chunk boundaries | It is deterministic pattern matching. It does not detect every encoding, paraphrase, or semantic disclosure, and it is not the complete HIPAA Safe Harbor method or Expert Determination. |
+
+## Regulatory boundaries
+
+Aegis can contribute technical inputs to a customer's own governance programme. It does not determine regulatory applicability, perform a conformity assessment, issue a certification, establish a lawful basis, or decide admissibility. Scope, configuration, retention, custody, operating effectiveness, and jurisdiction-specific conclusions belong to the deploying organization and its qualified reviewers.
+
+See [`compliance/COMPLIANCE_MAPPING.md`](compliance/COMPLIANCE_MAPPING.md) for the framework-by-framework mapping and [`institutional/DOC-05_REGULATORY_DOSSIER.md`](institutional/DOC-05_REGULATORY_DOSSIER.md) for the full dossier.
+
+## Deployment boundaries
+
+Topology determines evidence semantics. A single process with one worker and its own write-ahead log produces one process-local ordered sequence. Multiple workers sharing one log path do not, and that configuration is unsupported for a single ordered chain. Cross-process and cross-region total ordering is not implemented.
+
+See [`institutional/DOC-01_ENTERPRISE_ARCHITECTURE.md`](institutional/DOC-01_ENTERPRISE_ARCHITECTURE.md) section 8 for the topology matrix.
+
+## Threat-model non-goals
+
+Physical attacks, hypervisor or firmware compromise, host-root adversaries, micro-architectural side channels, guaranteed prevention of prompt injection, upstream provider trustworthiness, and network-layer denial of service are outside the model by design.
+
+See [`institutional/DOC-03_THREAT_MODEL.md`](institutional/DOC-03_THREAT_MODEL.md) section 5.3.
+
+## Evidence-state vocabulary
+
+| State | Meaning |
+|---|---|
+| **Implemented** | Source and regression tests establish the behavior under stated conditions. |
+| **Measured** | A named workload, revision, environment, date, and retained artifact establish a bounded result. |
+| **Configuration-dependent** | The control requires validation in the target deployment. |
+| **Roadmap** | Incomplete or unmeasured; must not be described as available. |
+| **Legal-review-required** | Regulatory, certification, procurement, contractual, and admissibility conclusions sit outside repository evidence. |
+
+## Related documents
+
+- [`docs/CLAIMS_MATRIX.md`](CLAIMS_MATRIX.md) — controlling public claims register.
+- [`docs/RELEASE_STATUS.md`](RELEASE_STATUS.md) — version, publication, and provenance record.
+- [`docs/institutional/UNSUPPORTED_CLAIMS.md`](institutional/UNSUPPORTED_CLAIMS.md) — claims explicitly not supported.
+- [`docs/security/THREAT_MODEL.md`](security/THREAT_MODEL.md) — security threat model.

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -1,0 +1,84 @@
+# Release Status and Provenance
+
+**Last verified:** 2026-09-01 UTC
+**Release baseline:** checked-out source baseline/release target `4.0.2` with fourteen synchronized anchors
+
+This document holds the complete version, publication, and provenance record so that `README.md` can state the current status once and link here. It is the authoritative place for release-lifecycle detail; the README is not.
+
+## Current status at a glance
+
+| Surface | Observed state | How to confirm it yourself |
+|---|---|---|
+| Source baseline | `4.0.2`, fourteen synchronized anchors | `python scripts/verify_release_contract.py --root . --tag v4.0.2` |
+| Git tag | `v4.0.2`, annotated and Sigstore-signed, resolving to commit `a6eb58dcc03f8b638c8f3e35f0300f5443a926ca` | `git show v4.0.2` after fetching tags |
+| GitHub Release | Present, non-draft, non-prerelease, 31 assets | [Release page](https://github.com/JuanLunaIA/aegis-latent-core/releases/tag/v4.0.2) |
+| PyPI (`aegis-latent-sdk`) | Observed at `4.0.0` | [PyPI project page](https://pypi.org/project/aegis-latent-sdk/) |
+| npm (`aegis-latent-sdk`) | Observed at `4.0.0` | [npm package page](https://www.npmjs.com/package/aegis-latent-sdk) |
+
+The gateway itself is not distributed on PyPI or npm. Those registries carry the SDKs only, so a source checkout is the supported way to run the gateway regardless of registry state.
+
+## Version anchors
+
+The release contract requires fourteen version anchors to agree before a tag is cut. At `4.0.2` they are: `core`, `core-runtime`, `python-sdk`, `python-sdk-runtime`, `typescript-sdk`, `typescript-lock`, `dashboard`, `dashboard-lock`, `rust-cargo`, `rust-pyproject`, `rust-lock`, `helm-chart`, `helm-app`, and `helm-image`.
+
+The immutable parent comparison commit `fdace8844568eb788216740b2cb5daf187d99d3b` retains fourteen synchronized `4.0.0` anchors and is the reference point for diffing source metadata between the two baselines.
+
+## Release envelope readback, 2026-09-01
+
+A read-only GitHub API readback recorded the following. It confirms that a release envelope exists with the expected shape; it is not a byte-level integrity check and not a registry publication.
+
+**Assets (31).** `SHA256SUMS`; `release-asset-manifest.json`; two SPDX SBOMs (`aegis-latent-core-4.0.2.spdx.json`, `aegis-latent-core-build-sbom.spdx.json`); the Python core wheel and sdist; the Python SDK wheel and sdist; the TypeScript tarball `aegis-latent-sdk-4.0.2.tgz`; and seven `aegis_rust-4.0.2-cp311-abi3` platform wheels covering macOS x86-64 and arm64, manylinux2014 x86-64, musllinux x86-64, aarch64 and armv7l, and Windows amd64. Every artifact ships a matching `.sha256` sidecar.
+
+**Tag signature.** The annotated tag carries a Sigstore keyless signature. The certificate's subject alternative name is the repository's own `create_release_tag.yml@refs/heads/main` workflow, the OIDC issuer is `token.actions.githubusercontent.com`, the trigger was `workflow_dispatch`, and the build environment was `release`.
+
+## Why GitHub shows the tag as unverified
+
+GitHub's native signature badge reports `v4.0.2` as unverified with reason `bad_cert`. **This is expected and is not a defect.**
+
+Sigstore issues short-lived certificates — valid for roughly ten minutes — and records the signing event in a public transparency log. GitHub's native verifier expects a long-lived GPG or S/MIME key it can resolve to a registered account, so a Fulcio certificate that has already expired by design reads as a bad certificate. The signature is validated against the transparency log rather than against certificate lifetime.
+
+To verify the tag properly, use a Sigstore-aware verifier and check the workflow identity rather than the GitHub badge:
+
+```bash
+# Verify the signed tag against the Sigstore transparency log.
+gitsign verify \
+  --certificate-identity 'https://github.com/JuanLunaIA/aegis-latent-core/.github/workflows/create_release_tag.yml@refs/heads/main' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  v4.0.2
+```
+
+A verification that succeeds establishes that the signing workflow in this repository produced the tag. It does not establish that the artifacts attached to the release were built from that tag; that is a separate attestation check.
+
+## Verifying release artifacts
+
+Download the assets and check them against the published digest list:
+
+```bash
+gh release download v4.0.2 --repo JuanLunaIA/aegis-latent-core --dir ./v4.0.2
+cd v4.0.2
+sha256sum --check --strict SHA256SUMS
+```
+
+For build provenance on the container images:
+
+```bash
+gh attestation verify oci://ghcr.io/juanlunaia/aegis-latent-core:4.0.2 \
+  --repo JuanLunaIA/aegis-latent-core
+```
+
+## Historical baseline
+
+The previous public label `v4.0.1` is a **lightweight** tag targeting `6469904380218584ae0b5221334bc9a46500f5ba`. Its tag-triggered workflows failed, so no artifact published under that label carries attributed provenance from those runs. The `4.0.0` objects observed on PyPI and npm predate and are unrelated to those failed runs.
+
+Two subsequent fixes addressed the tag-workflow failure: `a6eb58d` provisioned Python for the signed tag workflow, and `ed47d9c` bound publication dispatch to the signed target. The `v4.0.2` tag was cut after both landed.
+
+## What a version number does and does not tell you
+
+Source metadata is a statement about the working tree, not about the world. A synchronized anchor set means the repository agrees with itself; it does not mean a tag exists, a release was published, a registry accepted an upload, an image was pushed, a signature validates, or any deployment accepted the result. Each of those is a separate observable, and the commands in this document are how you check them.
+
+## Related documents
+
+- [`docs/CLAIMS_MATRIX.md`](CLAIMS_MATRIX.md) — controlling public claims register.
+- [`docs/BOUNDARIES.md`](BOUNDARIES.md) — consolidated product and evidence boundaries.
+- [`evidence/INDEX.md`](../evidence/INDEX.md) — dated evidence catalog.
+- [`SECURITY.md`](../SECURITY.md) — vulnerability reporting.

--- a/docs/operations/STORAGE_REQUIREMENTS.md
+++ b/docs/operations/STORAGE_REQUIREMENTS.md
@@ -1,0 +1,83 @@
+# Storage Requirements for the Evidence Path
+
+**Last verified:** 2026-09-01 UTC
+**Release baseline:** checked-out source baseline/release target `4.0.2` with fourteen synchronized anchors
+
+The evidence guarantee Aegis offers is *commit before response*: for a governed non-streaming call the record is written, flushed, and synchronized before the response returns, and for an admitted stream one terminal summary is committed before the terminal marker is emitted. That guarantee is only as strong as the storage underneath it. This document states what the gateway actually does, what the substrate must provide, and how to choose one.
+
+## What the gateway does
+
+On the authoritative JSONL path the commit sequence is: acquire the ledger lock, compute the chain node and signature, write the JSON line, flush the language-level buffer, then call `os.fsync()` on the file descriptor, and only then append the node to the in-memory window (`aegis/core/crypto_audit.py:417-419`). The awaiting request does not return until that sequence completes.
+
+On the optional native segment the sequence is: reserve an offset, copy the CRC32-framed payload into the memory map, write a zero-length terminator after it, call `flush_range`, and publish the new write position with a release store only after the flush returns (`aegis_rust_v2/src/wal.rs:134-175`).
+
+## What `fsync` actually guarantees
+
+`fsync(2)` asks the kernel to write dirty pages for that file descriptor from the page cache to the storage device and to wait for the device to acknowledge. When it returns zero, the kernel has been told the data is durable.
+
+It does not guarantee the bytes are on non-volatile media. Between the kernel and the NAND there is usually a volatile device write cache. If the drive acknowledges the write while the data still sits in that cache and power is lost before the cache is drained, the acknowledged write is gone. Nothing the application can do detects or prevents this — it is a property of the hardware.
+
+This is why the evidence claim is scoped as "the process requested synchronization" rather than "the record survived power loss." Closing that gap is a procurement decision, not a code change.
+
+## Required substrate properties
+
+| Property | Requirement | Why it matters here |
+|---|---|---|
+| Power-loss protection | Enterprise SSD or NVMe with on-device capacitors that flush the write cache on power failure, or a battery/flash-backed RAID controller | Without it, an acknowledged `fsync` can still be lost, which breaks commit-before-response at the physical layer |
+| Write cache policy | Volatile write cache disabled, or protected by the above | An unprotected cache silently converts a synchronous write into an asynchronous one |
+| Journaling | A filesystem that orders metadata and data consistently under power loss | A torn tail is detectable by CRC, but a corrupted directory entry can lose the whole segment |
+| Exclusive writer | One process per write-ahead log path | Concurrent writers to one path do not produce a single ordered chain; see the topology matrix in DOC-01 §8 |
+| Free-space headroom | Provision so the segment cannot reach capacity during a retention window | A full segment fails the append, which fails the request closed rather than silently dropping evidence |
+
+## Filesystem guidance
+
+| Filesystem | Configuration | Trade-off |
+|---|---|---|
+| ext4 | `data=ordered` is the default and is acceptable. `data=journal` writes data through the journal, which narrows the window in which a crash can expose a partially written record | `data=journal` costs write throughput because payload bytes are written twice |
+| XFS | Suitable with default settings; `nobarrier` must not be used | Disabling barriers removes the ordering that makes `fsync` meaningful |
+| ZFS | Well suited. A separate intent-log device (SLOG) with power-loss protection absorbs synchronous writes. Keep `sync=standard` | `sync=disabled` makes `fsync` a no-op and silently voids the commit-before-response property. Never set it on an evidence volume |
+| Btrfs | Usable, but validate the specific kernel and profile before adopting it for evidence | Historic issues have been profile-specific; test rather than assume |
+| Network filesystems | NFS and SMB are not recommended for the authoritative log | `fsync` semantics depend on server and mount options, and a client-side cache can acknowledge writes the server has not committed |
+
+## Cloud block storage
+
+Managed volumes hide the physical layer, so the questions change. Verify each of these against your provider's current documentation rather than against community lore, because the answers change between volume generations.
+
+1. **Does the volume acknowledge a synchronous write only after it is durably replicated?** This is the property that substitutes for on-device power-loss protection.
+2. **What is the IOPS and throughput floor at your sustained commit rate?** Because commit latency is request latency, a burst-credit volume that exhausts its balance converts into user-visible latency and, for streams, into producer backpressure.
+3. **Is the volume attached to exactly one instance?** Multi-attach breaks the exclusive-writer requirement.
+4. **What happens on instance stop, live migration, or host maintenance?** Ephemeral and instance-store volumes do not survive these events and are unsuitable for authoritative evidence.
+
+As a general shape: provisioned-IOPS volume classes are the appropriate starting point for an evidence path with a latency target, general-purpose classes are usually acceptable for evaluation and low-rate workloads, and local instance storage is appropriate only for throwaway environments.
+
+## Verifying your substrate
+
+Confirm the volume actually honors synchronous writes before trusting it. A synchronous write benchmark that reports latency far below the physical write latency of the device class is evidence that something in the stack is acknowledging early:
+
+```bash
+# Synchronous small-write latency on the evidence volume.
+fio --name=fsync-check --filename=/path/to/evidence/probe \
+    --rw=write --bs=4k --size=64M --fsync=1 --direct=1 \
+    --runtime=30 --time_based --group_reporting
+```
+
+Then remove the probe file. Interpret the result against the device class you believe you have; suspiciously low latency warrants investigating the write cache before the number is trusted.
+
+For power-loss behavior itself, the only real test is pulling power from the host under sustained write load and checking the tail afterwards. That test belongs in acceptance, not in production.
+
+## Consequences for the evidence claims
+
+If the substrate does not meet the requirements above, several statements weaken in specific ways, and the honest thing is to state which:
+
+- Commit-before-response remains true as program order but no longer implies survival of a power cut.
+- Inclusion proofs remain valid relative to a trusted root, but a truncated tail means some committed records may be absent from a later reconstruction, so completeness of the retained set is not established.
+- Chain verification over the retained window still detects modification; it cannot detect the loss of a valid tail without an externally retained expected count or root.
+
+None of this makes the evidence useless. It bounds what it demonstrates. Record the substrate you chose alongside the evidence it produced, so a later reviewer can evaluate both together.
+
+## Related documents
+
+- [`docs/institutional/DOC-01_ENTERPRISE_ARCHITECTURE.md`](../institutional/DOC-01_ENTERPRISE_ARCHITECTURE.md) — topology and failure semantics.
+- [`docs/institutional/DOC-04_OPERATIONS_PLAYBOOK.md`](../institutional/DOC-04_OPERATIONS_PLAYBOOK.md) — WAL stall and corruption runbooks.
+- [`docs/BOUNDARIES.md`](../BOUNDARIES.md) — consolidated evidence boundaries.
+- [`DEPLOYMENT_GUIDE.md`](../../DEPLOYMENT_GUIDE.md) — deployment gates.


### PR DESCRIPTION
## Change summary

Documentation and developer experience. Restructures the README around onboarding and relocates lifecycle and boundary detail into dedicated docs. **Content was moved, not deleted** — every statement removed from the README now lives in a linked document. Adds a root evaluation `docker-compose.yml`. No source code changes; the 14 version anchors stay at `4.0.2`.

### The two real defects this fixes

**1. Conditional SDK installs.** Both SDKs offered two install paths gated on registry readback state — *"After PyPI successfully publishes and readback confirms version 4.0.2, install… Until that readback succeeds, install the candidate from a pinned source checkout."* A reader had to resolve external registry state before running one command. Install is now unconditional from the cloned tree, with registry state noted once and linked.

**2. No evaluation path.** `deploy/docker/docker-compose.yml` exists but is strict-mode and fails closed without six secrets — correct for deployment, unusable for a first look. The new root compose file gives `docker compose up` against any OpenAI-compatible upstream.

### Hedging reduction

Version status was repeated in the header, §3, §5, §8, §9, §10 and the footer. It now appears once in a callout.

| Metric | Before | After |
|---|---|---|
| Word count | 4,356 | 3,777 *(while adding a Docker quickstart)* |
| "does not establish" | 14 | 6 |
| "readback" | 4 | 1 |
| Pricing figures | 1 | 0 |

Per-table evidence-boundary columns were **kept** — those carry real per-mechanism limits and are not boilerplate.

### New documents

- **`docs/RELEASE_STATUS.md`** — version anchors, release-envelope readback, `gitsign` and `SHA256SUMS` verification commands, historical `v4.0.1` baseline, and why GitHub shows the Sigstore tag as `bad_cert`.
- **`docs/BOUNDARIES.md`** — consolidated product, evidence, regulatory, deployment and threat-model boundaries plus the evidence-state vocabulary.
- **`docs/operations/STORAGE_REQUIREMENTS.md`** — closes a genuine gap: what `fsync` does and does not guarantee, power-loss-protection and write-cache requirements, filesystem guidance (including the ZFS `sync=disabled` hazard that silently voids commit-before-response), cloud volume selection criteria, an `fio` verification recipe, and which evidence claims weaken on an inadequate substrate.

### Scope notes

Three things were requested that I did not do, because acting on them would have caused damage:

- **No CI/CD rewrite.** The brief asked to fix a broken release pipeline. That failure was historical — fixed in #118/#119, after which `v4.0.2` shipped, and all 28 checks passed on #128. Rewriting three working workflows (112 SHA-pinned actions, signed-tag release path) against a stale premise risked breaking a working release for no verified defect.
- **No competitor comparison matrix.** I cannot verify current third-party feature sets, and publishing "competitor: NO" as fact would be unverifiable and unfair.
- **No claim that "Safe Harbor inspired" overstates the mechanism.** The README already states it is **not** the complete Safe Harbor method or Expert Determination.

## Type of change

- [x] Documentation update
- [x] Developer experience / infrastructure (new evaluation compose file)
- [ ] Bug fix / New feature / Breaking change / Security fix

## Evidence contract

- [x] No new public claim. The README now says less, not more; relocated text is unchanged in substance.
- [x] Every environment variable in the compose file was checked against a real settings field in `aegis/config.py`; `/health` and port `8080` verified in source.
- [x] `docs/BOUNDARIES.md` preserves every boundary removed from the README, and `CLAIMS_MATRIX.md` remains controlling.
- [x] No credentials, customer data, or private endpoints. The compose file takes the upstream key from the environment and hard-fails if the URL is unset.

## Verification

- [x] `verify_documentation.py --root . --strict` → **PASS, 0 errors, 0 warnings**
- [x] `verify_ai_context_manifest.py --root .` → **83 files**, anchor `fdace88…` unchanged (README is a governed input, so the manifest was regenerated)
- [x] `verify_release_contract.py --root . --tag v4.0.2` → **READY, 14/14 anchors at 4.0.2**
- [x] `pytest tests/test_ai_context.py tests/test_documentation_verifier.py` → 30 passed
- [x] Full suite `pytest -q` → **5,661 passed, 81 skipped, 0 failed**
- [x] Corpus sweep: **649 relative links, 0 broken**; UTF-8/NFC/LF clean
- [x] `docker-compose.yml` parsed and validated; `git diff --check` clean
- [ ] `docker compose up` **not executed** — Docker is unavailable in this container. The file is parser-validated with every variable checked against source, but the stack was not started here and should be smoke-tested before merge.

## Security and operations

- [x] No behavioral change to the gateway
- [x] The hardened `deploy/docker/` profile is untouched; the new file is explicitly labelled evaluation-only and documents the difference
- [x] `STORAGE_REQUIREMENTS.md` adds operational risk detail that was previously implicit

## Release impact

- [x] No version or changelog change; anchors untouched
- [x] Pricing removed from the README; ranges remain in `docs/COMMERCIAL_STRATEGY_US.md` framed as hypotheses
- [x] Human reviewer/owner: `@JuanLunaIA`

## Test plan

```
python tools/docs/verify_documentation.py --root . --strict      # PASS 0/0
python scripts/verify_ai_context_manifest.py --root .            # 83 files
python scripts/verify_release_contract.py --root . --tag v4.0.2  # READY 14/14
pytest tests/test_ai_context.py tests/test_documentation_verifier.py  # 30 passed
pytest -q                                                        # 5,661 passed
python -c "import yaml; yaml.safe_load(open('docker-compose.yml'))"   # valid
```

Recommended before merge: `AEGIS_BACKEND_URL=... docker compose up` on a machine with Docker, to confirm the evaluation path end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXm9uxZjTkDFnaV6U8R9oa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXm9uxZjTkDFnaV6U8R9oa)_

## Summary by Sourcery

Streamline onboarding and evidence documentation while adding a Docker evaluation path and explicit storage requirements.

New Features:
- Add an evaluation-only root Docker Compose quickstart for running the gateway against any OpenAI-compatible upstream.
- Add dedicated release-status, product-boundaries, and storage-requirements documentation.

Bug Fixes:
- Remove registry-dependent SDK installation instructions so both SDKs can be installed directly from the cloned source tree.

Enhancements:
- Restructure and streamline the README around onboarding, status, lifecycle, commercial guidance, and operational limitations while linking detailed material to dedicated documents.
- Clarify storage durability assumptions, filesystem and cloud-volume requirements, and how inadequate substrates affect evidence claims.

Documentation:
- Consolidate release provenance, evidence boundaries, and operational storage guidance into dedicated documentation and reduce repeated qualification in the README.

Tests:
- Regenerate the AI context manifest for the governed README changes and validate documentation, release anchors, links, Compose syntax, and the existing test suite.