### PR TITLE
perf(audit): constant-cost commits; fix(streaming, wal): stop aborting prose, stop truncating segments; verify(wal): Kani frame-bounds proofs

### DIFF
--- a/.aegis_ai_context/MANIFEST.json
+++ b/.aegis_ai_context/MANIFEST.json
@@ -105,8 +105,8 @@
     {
       "category": "governed_input",
       "path": "CHANGELOG.md",
-      "sha256": "94197eb40b63f5afcc133a0241114eb9de5b1e35183bbd5c806cfb7970ab8e9c",
-      "size": 44201
+      "sha256": "e28e6bd62850ee6fe85e702b59953d27ba0897e799f4aacbdbec4e9abe5c9072",
+      "size": 45202
     },
     {
       "category": "governed_input",
@@ -249,8 +249,8 @@
     {
       "category": "governed_input",
       "path": "aegis_rust_v2/Cargo.toml",
-      "sha256": "4552b1f53630cc965a603af93c6b4b5df6116f8148f600579f563c18647064fc",
-      "size": 4211
+      "sha256": "1e5ab4be568cf70e8b1120185d9720d3391fbf1c829e95dbdf7d69fec4d867b9",
+      "size": 4504
     },
     {
       "category": "governed_input",
@@ -321,8 +321,8 @@
     {
       "category": "governed_input",
       "path": ".github/workflows/ci.yml",
-      "sha256": "6656d88e30933309f52f15fd4d1727f389b6569dc73fe6a13c4aa99266015101",
-      "size": 24740
+      "sha256": "ba9ecd2f07c290fba3f5657e284e6ec77ebb893f229e6f0bae3d661215b1f8ab",
+      "size": 26071
     },
     {
       "category": "governed_input",

--- a/.aegis_ai_context/MANIFEST.json
+++ b/.aegis_ai_context/MANIFEST.json
@@ -105,8 +105,8 @@
     {
       "category": "governed_input",
       "path": "CHANGELOG.md",
-      "sha256": "fe8d8fad19791048e3f3368e508dc9f95c7eb134713f23d2f9af79dc6588dbb2",
-      "size": 42170
+      "sha256": "94197eb40b63f5afcc133a0241114eb9de5b1e35183bbd5c806cfb7970ab8e9c",
+      "size": 44201
     },
     {
       "category": "governed_input",
@@ -183,8 +183,8 @@
     {
       "category": "governed_input",
       "path": "evidence/INDEX.md",
-      "sha256": "bae28a07befa15bd16c29878bbc459bb569a026c0708ef8ee92ee642244ae695",
-      "size": 9721
+      "sha256": "aff9aca774cdc58f6b725337ccd0f9c63fbfc02c4fd6f73ee446c49aea3d1f30",
+      "size": 10067
     },
     {
       "category": "governed_input",

--- a/.aegis_ai_context/MANIFEST.json
+++ b/.aegis_ai_context/MANIFEST.json
@@ -321,8 +321,8 @@
     {
       "category": "governed_input",
       "path": ".github/workflows/ci.yml",
-      "sha256": "ba9ecd2f07c290fba3f5657e284e6ec77ebb893f229e6f0bae3d661215b1f8ab",
-      "size": 26071
+      "sha256": "2e65d2383ed54e0236234b3009a96d9d40c6e9d434ecb6aa2da9a5638a6fe4f3",
+      "size": 26740
     },
     {
       "category": "governed_input",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,6 +430,16 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      # Kani builds the whole crate, so pyo3's build script runs and refuses any
+      # interpreter below the `abi3-py311` floor. ubuntu-22.04 ships Python 3.10,
+      # which fails with "cannot set a minimum Python version 3.11 higher than
+      # the interpreter version 3.10". Unlike the `rust` job,
+      # PYO3_USE_ABI3_FORWARD_COMPATIBILITY does not help — it was verified not
+      # to change that error — so an interpreter at or above the floor is the
+      # requirement, and this step is what supplies it.
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install pinned Kani
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,32 @@ jobs:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
         run: maturin build --release --features extension-module
 
+  # ── Model checking ────────────────────────────────────────────────────────
+  # Bit-level proofs over the WAL's frame-bounds arithmetic. Scope and limits:
+  # docs/formal/FORMAL_VERIFICATION_LIMITS.md.
+  #
+  # Kept out of the `rust` job because `cargo kani setup` downloads its own
+  # nightly toolchain and CBMC bundle, which would slow every Rust run. It is
+  # also deliberately absent from the `docker` job's `needs`: that download is a
+  # network dependency this repository does not control, and a release should
+  # not become unshippable because a third-party bundle host is unavailable.
+  # The proofs therefore run as a PR check, not as a release gate.
+  kani:
+    name: Kani Model Checking
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - name: Install pinned Kani
+        run: |
+          set -euo pipefail
+          cargo install --locked --version 0.67.0 kani-verifier
+          cargo kani setup
+          cargo kani --version
+      - name: Verify WAL frame-bounds proofs
+        working-directory: aegis_rust_v2
+        run: cargo kani
+
   # ── Security scan ─────────────────────────────────────────────────────────
   security:
     name: Security Scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ external readback facts recorded in `docs/RELEASE_STATUS.md`.
 - DNS egress in the Helm `NetworkPolicy` scoped to resolver pods via a `podSelector`; a namespace-only peer permitted port 53 to every pod in `kube-system` while the comment claimed otherwise.
 - Three stale heading anchors in `docs/architecture/DEEP_DIVE.md` pointing at `docs/BENCHMARKS.md` sections that no longer exist.
 - Stale `rollout status` commands in `docs/institutional/DOC-04_OPERATIONS_PLAYBOOK.md` naming `deployment/` and omitting the release prefix.
+- Streaming redaction aborted ordinary text. `StreamingDeidentifier` rejected an open track-data candidate whenever a semicolon was followed by more than `window_chars` of text containing no `?`, and an open email candidate whenever an `@` appeared anywhere in the holdback window rather than in the trailing whitespace-free token. Prose containing a semicolon, a mentioned email address, or a Python decorator therefore raised `StreamingDeidentificationError`, which the proxy reports to the client as a `privacy_failure` terminal outcome. Each guard now tests whether the candidate is a viable prefix of the detector that would redact it.
+- Open-candidate marker searches are now case-insensitive, matching the URL and track-1 detectors. An unterminated `HTTPS://` or `%b` candidate previously passed the guard entirely, which was a fail-open on the exact grammar the guard exists to catch.
 
 ## [4.0.2] — 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ external readback facts recorded in `docs/RELEASE_STATUS.md`.
 - `MerkleMountainRange.checkpoint()` and `rollback_to()`: an O(log n) rollback token that records the append-only lengths and the live peak nodes, replacing a whole-structure snapshot on the commit path.
 - Regression coverage for MMR append rollback (`tests/test_mmr_rollback.py`) and for chain integrity across memory-window rollover (`tests/test_crypto_audit_rollover.py`), including a `slow`-marked 100,000-node sweep through a 512-node window. Both the rollback path and the window anchor were previously unasserted.
 - Rust↔Python MMR parity extended beyond root equality: Python-generated portable proofs are verified against the Rust-reported root, `RustBackedMMR` is checked end to end, and the `sha256-asciihex` wire literal is pinned to the digest both implementations actually compute.
+- Kani model checking of the native WAL's frame-bounds arithmetic. `header_range` and `payload_range` in `aegis_rust_v2/src/wal.rs` now bound every slice taken during a frame walk, and five `#[kani::proof]` harnesses check over the whole `usize` domain that the returned ranges stay inside the limit, never overflow, never treat the zero-length recovery terminator as a frame, always advance the cursor, and never overlap. Wired into CI as a `Kani Model Checking` job pinned to Kani 0.67.0; scope and limits recorded in `docs/formal/FORMAL_VERIFICATION_LIMITS.md`.
 
 ### Changed
 
@@ -47,6 +48,7 @@ external readback facts recorded in `docs/RELEASE_STATUS.md`.
 - Stale `rollout status` commands in `docs/institutional/DOC-04_OPERATIONS_PLAYBOOK.md` naming `deployment/` and omitting the release prefix.
 - Streaming redaction aborted ordinary text. `StreamingDeidentifier` rejected an open track-data candidate whenever a semicolon was followed by more than `window_chars` of text containing no `?`, and an open email candidate whenever an `@` appeared anywhere in the holdback window rather than in the trailing whitespace-free token. Prose containing a semicolon, a mentioned email address, or a Python decorator therefore raised `StreamingDeidentificationError`, which the proxy reports to the client as a `privacy_failure` terminal outcome. Each guard now tests whether the candidate is a viable prefix of the detector that would redact it.
 - Open-candidate marker searches are now case-insensitive, matching the URL and track-1 detectors. An unterminated `HTTPS://` or `%b` candidate previously passed the guard entirely, which was a fail-open on the exact grammar the guard exists to catch.
+- `RustWal.open` truncated an existing segment when reopened with a smaller `capacity_bytes`. `OpenOptions::truncate(false)` prevents `open` from clearing the file, but the subsequent `set_len` shrank it just the same, discarding every frame past the new length — a 1 MiB segment holding 20 records reopened at 64 bytes retained 4. The requested capacity is now a floor rather than a resize instruction, so a segment only ever grows.
 
 ## [4.0.2] — 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,16 @@ external readback facts recorded in `docs/RELEASE_STATUS.md`.
 - Documentation corpus: claim-control foundations (`docs/STYLE_GUIDE.md`, `docs/DOCUMENTATION_GOVERNANCE.md`, `docs/INDEX.md`), security volume, operations runbooks, API references, four framework technical-input documents, privacy boundaries, enterprise and corporate volumes, assurance index, and root governance files.
 - Four documentation gates run in CI: `scripts/verify_docs.py`, `scripts/verify_claims.py`, `scripts/verify_links.sh`, and the pre-existing `tools/docs/verify_documentation.py`.
 - Eleven claims-matrix rows covering the `fsync` durability boundary, trusted-root independence, the native WAL's auxiliary role, `pending-terminal` semantics, redaction as best-effort, registry publication state, the `bad_cert` explanation, and explicit denials for production SLO, WORM and immutability; stable `CLM-NNN` identifiers on all 53 rows.
+- `MerkleMountainRange.checkpoint()` and `rollback_to()`: an O(log n) rollback token that records the append-only lengths and the live peak nodes, replacing a whole-structure snapshot on the commit path.
+- Regression coverage for MMR append rollback (`tests/test_mmr_rollback.py`) and for chain integrity across memory-window rollover (`tests/test_crypto_audit_rollover.py`), including a `slow`-marked 100,000-node sweep through a 512-node window. Both the rollback path and the window anchor were previously unasserted.
+- Rust↔Python MMR parity extended beyond root equality: Python-generated portable proofs are verified against the Rust-reported root, `RustBackedMMR` is checked end to end, and the `sha256-asciihex` wire literal is pinned to the digest both implementations actually compute.
 
 ### Changed
 
 - Least-privilege `GITHUB_TOKEN`: read-only workflow-level floor in `ci.yml` and `forensic.yml`, and `security-events: write` moved from workflow scope to the four SARIF-uploading jobs in `security.yml`.
 - `README.md` restructured and reduced from roughly 33 KB to 13 KB, stating release status once and routing to `docs/RELEASE_STATUS.md`.
 - `docs/RELEASE_STATUS.md` records a 2026-09-02 readback of every publication surface, with per-surface commands and a publication-state table.
+- `CryptographicAuditLedger` reverts a failed commit through the MMR checkpoint instead of `copy.deepcopy`. The deep copy ran on every commit and copied the whole accumulator, so per-commit cost grew with the length of the chain. Failure semantics are unchanged: a signing or WAL-persistence failure still leaves the MMR exactly as it was.
 
 ### Fixed
 

--- a/aegis/core/crypto_audit.py
+++ b/aegis/core/crypto_audit.py
@@ -39,7 +39,6 @@ FIX-CAL-01: WAL file handle lifecycle.
 # Proprietary Commercial License. See LICENSE and COMMERCIAL.md for terms.
 from __future__ import annotations
 
-import copy
 import hashlib
 import hmac
 import json
@@ -445,7 +444,10 @@ class CryptographicAuditLedger:
         with self._lock:
             prev_hash = self.chain[-1].node_hash if self.chain else "0" * 64
             timestamp = time.time()
-            mmr_before = copy.deepcopy(self._mmr)
+            # O(log n) rollback token, not a copy of the accumulator: this runs
+            # on every commit, so a deep copy would make commit cost grow with
+            # the length of the chain.
+            mmr_before = self._mmr.checkpoint()
             merkle_root = self._mmr.add_leaf(leaf)
             mmr_leaf_count = self._mmr.get_leaf_count()
             mmr_leaf_index = mmr_leaf_count - 1
@@ -464,7 +466,7 @@ class CryptographicAuditLedger:
             try:
                 signature, pub_key_hex, scheme, is_fallback = self._sign(signed_payload)
             except Exception:
-                self._mmr = mmr_before
+                self._mmr.rollback_to(mmr_before)
                 self._fault_state = "signing_failed"
                 raise
 
@@ -498,7 +500,7 @@ class CryptographicAuditLedger:
             try:
                 self._persist_node(node)
             except Exception:
-                self._mmr = mmr_before
+                self._mmr.rollback_to(mmr_before)
                 self._fault_state = "wal_persist_failed"
                 raise
             self._append_memory_node(node)
@@ -622,7 +624,8 @@ class CryptographicAuditLedger:
         with self._lock:
             prev_hash = self.chain[-1].node_hash if self.chain else "0" * 64
             timestamp = time.time()
-            mmr_before = copy.deepcopy(self._mmr)
+            # See commit_forensic: rollback token rather than a snapshot.
+            mmr_before = self._mmr.checkpoint()
             merkle_root = self._mmr.add_leaf(leaf)
             mmr_leaf_count = self._mmr.get_leaf_count()
             mmr_leaf_index = mmr_leaf_count - 1
@@ -637,7 +640,7 @@ class CryptographicAuditLedger:
             try:
                 signature, pub_key_hex, scheme, is_fallback = self._sign(signed_payload)
             except Exception:
-                self._mmr = mmr_before
+                self._mmr.rollback_to(mmr_before)
                 self._fault_state = "signing_failed"
                 raise
             node = AuditNode(
@@ -670,7 +673,7 @@ class CryptographicAuditLedger:
             try:
                 self._persist_node(node)
             except Exception:
-                self._mmr = mmr_before
+                self._mmr.rollback_to(mmr_before)
                 self._fault_state = "wal_persist_failed"
                 raise
             self._append_memory_node(node)

--- a/aegis/core/mmr.py
+++ b/aegis/core/mmr.py
@@ -36,6 +36,22 @@ class MMRNode:
 
 
 @dataclass(frozen=True)
+class MMRAppendCheckpoint:
+    """Opaque marker for the MMR state preceding one or more appends.
+
+    Holds the append-only lengths plus the peak node objects that were live at
+    capture time. It is a rollback token, not a copy: it borrows references
+    into the owning MMR and is only meaningful for the instance that produced
+    it. See :meth:`MerkleMountainRange.checkpoint`.
+    """
+
+    node_count: int
+    leaf_node_index_count: int
+    leaf_count: int
+    peaks: tuple[MMRNode, ...]
+
+
+@dataclass(frozen=True)
 class MMRProofStep:
     sibling_hash: str
     direction: str
@@ -148,6 +164,52 @@ class MerkleMountainRange:
 
         self.peaks.append(current_node)
         return self.get_root_hash()
+
+    def checkpoint(self) -> MMRAppendCheckpoint:
+        """Capture the current state so a later append can be undone exactly.
+
+        Costs O(number of peaks) = O(log n), against O(n) for a deep copy of
+        the whole structure. Callers that must revert an append on a
+        downstream failure — the audit chain reverts when signing or WAL
+        persistence fails — should pair this with :meth:`rollback_to` rather
+        than snapshotting the MMR.
+
+        The token borrows the live peak node objects, so it is valid only for
+        the instance that produced it and only until it is used.
+        """
+        return MMRAppendCheckpoint(
+            node_count=len(self.nodes),
+            leaf_node_index_count=len(self._leaf_node_indices),
+            leaf_count=self._leaf_count,
+            peaks=tuple(self.peaks),
+        )
+
+    def rollback_to(self, checkpoint: MMRAppendCheckpoint) -> None:
+        """Restore the exact state captured by ``checkpoint``.
+
+        Appends only ever extend ``nodes`` and ``_leaf_node_indices`` and only
+        ever mutate ``parent`` on nodes as they are popped from ``peaks``. A
+        node in ``peaks`` therefore always has ``parent is None``, so
+        truncating the two lists and reinstating the recorded peaks with
+        cleared parents reproduces the prior state byte-for-byte.
+
+        Raises:
+            ValueError: If the checkpoint does not describe a prefix of the
+                current state, which would mean it came from another instance
+                or the MMR was truncated behind it.
+        """
+        if (
+            checkpoint.node_count > len(self.nodes)
+            or checkpoint.leaf_node_index_count > len(self._leaf_node_indices)
+            or checkpoint.leaf_count > self._leaf_count
+        ):
+            raise ValueError("MMR checkpoint does not describe a prefix of the current state")
+        del self.nodes[checkpoint.node_count :]
+        del self._leaf_node_indices[checkpoint.leaf_node_index_count :]
+        self._leaf_count = checkpoint.leaf_count
+        self.peaks = list(checkpoint.peaks)
+        for peak in self.peaks:
+            peak.parent = None
 
     def get_root_hash(self) -> str:
         """

--- a/aegis/core/streaming_deidentifier.py
+++ b/aegis/core/streaming_deidentifier.py
@@ -32,6 +32,28 @@ class StreamingDeidentificationError(ValueError):
     """Raised when a sensitive candidate exceeds the finite stream grammar."""
 
 
+# Viable prefixes of the detectors in ``pci_detector``. A candidate is only an
+# open track-data candidate if the pattern that would redact it could still
+# complete from what has arrived so far. Testing only for the absence of the
+# ``?`` terminator is far too loose: every semicolon in ordinary prose starts a
+# run with no ``?`` in it.
+#
+# _TRACK1 = %B\d{12,19}\^[^^]{2,26}\^\d{4,}[^?]*\?  → still inside the PAN, or
+#                                                     past the first caret.
+# _TRACK2 = ;\d{12,19}=\d{4,}[^?]*\?                → still inside the PAN, or
+#                                                     past the field separator.
+_TRACK1_OPEN_PREFIX = re.compile(r"%B(?:\d{0,19}|\d{12,19}\^[^?]*)$", re.IGNORECASE)
+_TRACK2_OPEN_PREFIX = re.compile(r";(?:\d{0,19}|\d{12,19}=[^?]*)$")
+
+# A URL candidate is open until one of the characters that ends the URL
+# grammar appears; mirrors the ``[^\s"'<>)\]]+`` body of the URL detector.
+_URL_TERMINATOR = re.compile(r"[\s\"'<>)\]]")
+
+# The trailing run with no whitespace in it. The EMAIL detector admits no
+# whitespace, so this is exactly the token that could still become an address.
+_TRAILING_TOKEN = re.compile(r"\S*$")
+
+
 @dataclass(frozen=True)
 class StreamRedactionStats:
     """Bounded, non-sensitive redaction counters."""
@@ -118,38 +140,52 @@ class StreamingDeidentifier:
         return output
 
     def _reject_overlong_open_candidate(self, cutoff: int, *, final: bool = False) -> None:
-        """Fail closed for the established unbounded URL/track grammars."""
+        """Fail closed for candidates that cannot settle inside the window.
+
+        A candidate is rejected only when it is a viable *prefix* of the
+        detector that would redact it. Looser tests reject ordinary prose:
+        matching every semicolon that is not followed by a ``?``, or treating
+        the whole holdback as one token when looking for an ``@``, aborts any
+        stream that happens to contain a semicolon or mention an email address.
+        Both are ordinary text, and an aborted stream is reported to the client
+        as ``privacy_failure``.
+
+        Marker searches are case-insensitive because the URL and track-1
+        detectors are; searching for the lowercase form alone let an uppercase
+        ``HTTPS://`` or ``%b`` candidate past the guard entirely.
+        """
         if cutoff <= 0:
             return
         lower = self._pending.lower()
-        starts = [
-            lower.rfind("http://", 0, cutoff),
-            lower.rfind("https://", 0, cutoff),
-            self._pending.rfind("%B", 0, cutoff),
-            self._pending.rfind(";", 0, cutoff),
-        ]
-        for start in starts:
+
+        for marker in ("http://", "https://"):
+            start = lower.rfind(marker, 0, cutoff)
             if start < 0:
                 continue
             candidate = self._pending[start:]
-            if len(candidate) <= self.window_chars:
+            if len(candidate) > self.window_chars and not _URL_TERMINATOR.search(candidate):
+                raise StreamingDeidentificationError("overlong open URL candidate")
+
+        for marker, open_prefix in (("%b", _TRACK1_OPEN_PREFIX), (";", _TRACK2_OPEN_PREFIX)):
+            start = lower.rfind(marker, 0, cutoff)
+            if start < 0:
                 continue
-            if candidate.startswith(("http://", "https://")):
-                if not re.search(r"[\s\"'<>)\]]", candidate):
-                    raise StreamingDeidentificationError("overlong open URL candidate")
-            elif candidate.startswith(("%B", ";")) and "?" not in candidate:
+            candidate = self._pending[start:]
+            if (
+                len(candidate) > self.window_chars
+                and "?" not in candidate
+                and open_prefix.match(candidate) is not None
+            ):
                 raise StreamingDeidentificationError("overlong open track-data candidate")
-        token_start = (
-            max(
-                self._pending.rfind(" ", 0, cutoff),
-                self._pending.rfind("\n", 0, cutoff),
-                self._pending.rfind("\t", 0, cutoff),
-            )
-            + 1
-        )
-        open_token = self._pending[token_start:]
-        if "@" in open_token and len(open_token) > self.window_chars:
-            raise StreamingDeidentificationError("overlong open email candidate")
+
+        # The EMAIL detector admits no whitespace, so the open candidate is the
+        # trailing whitespace-free run — not everything after the last space
+        # that preceded the cutoff, which spans whole settled words.
+        open_token = _TRAILING_TOKEN.search(self._pending)
+        if open_token is not None:
+            token = open_token.group(0)
+            if "@" in token and len(token) > self.window_chars:
+                raise StreamingDeidentificationError("overlong open email candidate")
         address = re.search(r"(?:^|\b)\d{1,5}\s+[A-Za-z0-9 ]+$", self._pending)
         if address is not None and len(address.group(0)) > self.window_chars:
             raise StreamingDeidentificationError("overlong open address candidate")

--- a/aegis_rust_v2/Cargo.toml
+++ b/aegis_rust_v2/Cargo.toml
@@ -26,6 +26,12 @@ full = ["extension-module"]  # All features
 name = "aegis_rust"
 crate-type = ["cdylib", "rlib"]
 
+[lints.rust]
+# `kani` is set by the Kani model checker, not by cargo. Declaring it here keeps
+# `cargo clippy -- -D warnings` from rejecting the `#[cfg(kani)]` proof module,
+# while an actual typo in a cfg name is still caught.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
+
 [dependencies]
 # Python bindings
 pyo3 = { version = "0.29", features = ["abi3-py311"] }

--- a/aegis_rust_v2/src/wal.rs
+++ b/aegis_rust_v2/src/wal.rs
@@ -28,6 +28,7 @@ use parking_lot::Mutex;
 use pyo3::prelude::*;
 use std::{
     fs::OpenOptions,
+    ops::Range,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -39,6 +40,40 @@ const DEFAULT_SEGMENT_BYTES: usize = 256 * 1024 * 1024;
 
 /// [crc32: 4 B][len: 4 B]
 const FRAME_HEADER: usize = 8;
+
+/// Byte range of the frame header at `pos`, if the whole header fits in `limit`.
+///
+/// Every frame walk in this module bounds its slicing through this function and
+/// [`payload_range`] rather than through open-coded `pos + FRAME_HEADER + len`
+/// comparisons, so the arithmetic that decides whether a slice is in bounds
+/// exists in exactly one place and can be model-checked. See the `kani` module
+/// at the bottom of this file.
+#[inline]
+fn header_range(pos: usize, limit: usize) -> Option<Range<usize>> {
+    let end = pos.checked_add(FRAME_HEADER)?;
+    if end > limit {
+        return None;
+    }
+    Some(pos..end)
+}
+
+/// Byte range of a `payload_len`-byte payload following the header at `pos`,
+/// if the whole payload fits in `limit`.
+///
+/// A zero-length payload is refused: a zero length is the recovery terminator
+/// written after the valid prefix, never a real frame.
+#[inline]
+fn payload_range(pos: usize, payload_len: usize, limit: usize) -> Option<Range<usize>> {
+    if payload_len == 0 {
+        return None;
+    }
+    let start = pos.checked_add(FRAME_HEADER)?;
+    let end = start.checked_add(payload_len)?;
+    if end > limit {
+        return None;
+    }
+    Some(start..end)
+}
 
 struct WalInner {
     mmap: Mutex<MmapMut>,
@@ -86,6 +121,26 @@ impl RustWal {
             use std::os::unix::fs::PermissionsExt;
             let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
         }
+
+        // A segment may only grow. `OpenOptions::truncate(false)` stops `open`
+        // from clearing the file, but `set_len` to a smaller size truncates it
+        // just the same: reopening a populated 256 MiB segment with a smaller
+        // `capacity_bytes` discarded every frame past the new length. Take the
+        // larger of the requested capacity and the existing file, so a
+        // misconfigured or downgraded caller cannot destroy committed frames.
+        let existing_len = file
+            .metadata()
+            .map_err(|e| {
+                PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("RustWal metadata: {e}"))
+            })?
+            .len();
+        let capacity = usize::try_from(existing_len)
+            .map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyOverflowError, _>(
+                    "RustWal segment is larger than this platform's address space",
+                )
+            })?
+            .max(capacity);
 
         file.set_len(capacity as u64).map_err(|e| {
             PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("RustWal resize: {e}"))
@@ -183,16 +238,23 @@ impl RustWal {
         let mut records = Vec::new();
         let mut pos = 0usize;
 
-        while pos + FRAME_HEADER <= limit {
-            let stored_crc = u32::from_le_bytes(mmap[pos..pos + 4].try_into().unwrap_or([0; 4]));
-            let payload_len =
-                u32::from_le_bytes(mmap[pos + 4..pos + 8].try_into().unwrap_or([0; 4])) as usize;
+        while let Some(header) = header_range(pos, limit) {
+            let stored_crc = u32::from_le_bytes(
+                mmap[header.start..header.start + 4]
+                    .try_into()
+                    .unwrap_or([0; 4]),
+            );
+            let payload_len = u32::from_le_bytes(
+                mmap[header.start + 4..header.end]
+                    .try_into()
+                    .unwrap_or([0; 4]),
+            ) as usize;
 
-            if payload_len == 0 || pos + FRAME_HEADER + payload_len > limit {
+            let Some(body) = payload_range(pos, payload_len, limit) else {
                 break;
-            }
+            };
 
-            let payload = &mmap[pos + FRAME_HEADER..pos + FRAME_HEADER + payload_len];
+            let payload = &mmap[body.clone()];
             let mut crc = Crc32Hasher::new();
             crc.update(payload);
             if crc.finalize() != stored_crc {
@@ -203,7 +265,7 @@ impl RustWal {
                 records.push(s.to_string());
             }
 
-            pos += FRAME_HEADER + payload_len;
+            pos = body.end;
         }
 
         Ok(records)
@@ -227,28 +289,27 @@ impl RustWal {
 /// Scan the mmap to find the byte offset of the first unwritten frame.
 fn scan_write_pos(mmap: &MmapMut, capacity: usize) -> usize {
     let mut pos = 0usize;
-    while pos + FRAME_HEADER <= capacity {
-        let stored_crc = u32::from_le_bytes(mmap[pos..pos + 4].try_into().unwrap_or([0; 4]));
-        let len = u32::from_le_bytes(mmap[pos + 4..pos + 8].try_into().unwrap_or([0; 4])) as usize;
-        if len == 0 {
-            break;
-        }
-        let Some(end) = pos
-            .checked_add(FRAME_HEADER)
-            .and_then(|payload_start| payload_start.checked_add(len))
-        else {
+    while let Some(header) = header_range(pos, capacity) {
+        let stored_crc = u32::from_le_bytes(
+            mmap[header.start..header.start + 4]
+                .try_into()
+                .unwrap_or([0; 4]),
+        );
+        let len = u32::from_le_bytes(
+            mmap[header.start + 4..header.end]
+                .try_into()
+                .unwrap_or([0; 4]),
+        ) as usize;
+        let Some(body) = payload_range(pos, len, capacity) else {
             break;
         };
-        if end > capacity {
-            break;
-        }
-        let payload = &mmap[pos + FRAME_HEADER..end];
+        let payload = &mmap[body.clone()];
         let mut crc = Crc32Hasher::new();
         crc.update(payload);
         if crc.finalize() != stored_crc || std::str::from_utf8(payload).is_err() {
             break;
         }
-        pos = end;
+        pos = body.end;
     }
     pos
 }
@@ -371,5 +432,142 @@ mod tests {
             reopened.read_all().unwrap(),
             vec!["AAAA".to_string(), "DDDD".to_string()]
         );
+    }
+
+    #[test]
+    fn reopening_with_a_smaller_capacity_does_not_truncate_the_segment() {
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_str().unwrap().to_string();
+        let expected: Vec<String> = (0..20).map(|i| format!("record-{i:04}")).collect();
+        let written_bytes;
+        {
+            let wal = RustWal::open(&path, Some(64 * 1024)).unwrap();
+            for record in &expected {
+                wal.append(record).unwrap();
+            }
+            written_bytes = wal.write_pos();
+            assert_eq!(wal.read_all().unwrap(), expected);
+        }
+
+        // A caller that asks for less than the segment already holds must not
+        // be able to discard committed frames. `set_len` shrinks a file just as
+        // `truncate(true)` would, so the requested capacity is a floor, not a
+        // resize instruction.
+        let reopened = RustWal::open(&path, Some(64)).unwrap();
+        assert_eq!(reopened.read_all().unwrap(), expected);
+        assert_eq!(reopened.write_pos(), written_bytes);
+        assert_eq!(reopened.capacity(), 64 * 1024);
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 64 * 1024);
+    }
+
+    #[test]
+    fn reopening_with_a_larger_capacity_still_grows_the_segment() {
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_str().unwrap().to_string();
+        {
+            let wal = RustWal::open(&path, Some(4096)).unwrap();
+            wal.append("AAAA").unwrap();
+        }
+
+        let grown = RustWal::open(&path, Some(16 * 1024)).unwrap();
+        assert_eq!(grown.capacity(), 16 * 1024);
+        assert_eq!(grown.read_all().unwrap(), vec!["AAAA".to_string()]);
+    }
+}
+
+/// Bit-level model checking of the WAL's frame-bounds arithmetic.
+///
+/// Kani explores every value of the inputs symbolically rather than sampling
+/// them, so these are proofs over the whole `usize` domain — not tests. They
+/// cover exactly what is provable here: the arithmetic that decides whether a
+/// slice is in bounds, and the walk's termination.
+///
+/// They do **not** cover the mmap itself. Kani cannot model `mmap`, `flush` or
+/// the filesystem, so nothing here establishes durability, crash consistency,
+/// concurrent-append behaviour, or that `capacity` equals the mapped length.
+/// Those remain the responsibility of `open`, the mutex, and the unit tests.
+///
+/// Run with `cargo kani --harness <name>` from `aegis_rust_v2/`.
+#[cfg(kani)]
+mod verification {
+    use super::{header_range, payload_range, FRAME_HEADER};
+
+    /// A header range, when returned, is inside `limit` and is exactly one
+    /// header long. Nothing else can produce an in-bounds slice.
+    #[kani::proof]
+    fn header_range_is_in_bounds() {
+        let pos: usize = kani::any();
+        let limit: usize = kani::any();
+
+        match header_range(pos, limit) {
+            Some(range) => {
+                assert!(range.start == pos);
+                assert!(range.end <= limit);
+                assert!(range.end - range.start == FRAME_HEADER);
+            }
+            None => {
+                // Refusal is only ever for overflow or for not fitting.
+                assert!(pos.checked_add(FRAME_HEADER).is_none_or(|end| end > limit));
+            }
+        }
+    }
+
+    /// A payload range, when returned, is inside `limit`, starts immediately
+    /// after the header, and is exactly `payload_len` bytes long.
+    #[kani::proof]
+    fn payload_range_is_in_bounds() {
+        let pos: usize = kani::any();
+        let payload_len: usize = kani::any();
+        let limit: usize = kani::any();
+
+        if let Some(range) = payload_range(pos, payload_len, limit) {
+            assert!(range.end <= limit);
+            assert!(range.start >= pos);
+            assert!(range.start - pos == FRAME_HEADER);
+            assert!(range.end - range.start == payload_len);
+            assert!(payload_len > 0);
+        }
+    }
+
+    /// The recovery terminator is never mistaken for a frame: a zero-length
+    /// payload is refused at every position and every limit.
+    #[kani::proof]
+    fn zero_length_payload_is_never_a_frame() {
+        let pos: usize = kani::any();
+        let limit: usize = kani::any();
+
+        assert!(payload_range(pos, 0, limit).is_none());
+    }
+
+    /// A frame walk strictly advances. `pos = body.end` with `body.end >
+    /// pos` is what makes both `read_all` and `scan_write_pos` terminate; a
+    /// frame that did not advance the cursor would loop forever on a mapping
+    /// an attacker controls the bytes of.
+    #[kani::proof]
+    fn a_frame_walk_strictly_advances() {
+        let pos: usize = kani::any();
+        let payload_len: usize = kani::any();
+        let limit: usize = kani::any();
+
+        if let Some(body) = payload_range(pos, payload_len, limit) {
+            assert!(body.end > pos);
+            assert!(body.end <= limit);
+        }
+    }
+
+    /// Header and payload ranges never overlap, so a frame's length field can
+    /// never be read out of its own payload.
+    #[kani::proof]
+    fn header_and_payload_do_not_overlap() {
+        let pos: usize = kani::any();
+        let payload_len: usize = kani::any();
+        let limit: usize = kani::any();
+
+        if let (Some(header), Some(body)) = (
+            header_range(pos, limit),
+            payload_range(pos, payload_len, limit),
+        ) {
+            assert!(header.end <= body.start);
+        }
     }
 }

--- a/benchmarks/bench_commit_scaling.py
+++ b/benchmarks/bench_commit_scaling.py
@@ -1,0 +1,216 @@
+"""
+Commit-cost scaling benchmark — per-commit latency as a function of chain length.
+
+``benchmarks/bench_crypto_audit.py`` measures commit throughput at one fixed N,
+which cannot distinguish a constant per-commit cost from one that grows with the
+number of leaves already in the MMR. This benchmark varies the chain length and
+reports the per-commit latency at each, so a change with the wrong asymptotic
+shape shows up as a rising column rather than as a slightly worse single number.
+
+That distinction is load-bearing here: the ledger reverts a failed commit by
+restoring the MMR, and the revert used to be a ``copy.deepcopy`` of the whole
+accumulator taken on *every* commit — including the overwhelming majority that
+succeed. Cost per commit therefore grew with the chain, and the growth was
+invisible to a fixed-N benchmark.
+
+Boundary
+--------
+This is an in-process microbenchmark of the commit path only. It excludes the
+network, the upstream provider, request parsing, admission control, WAF
+evaluation, and response handling. By default it also installs a no-op
+``fsync_fn``, which removes durable-write cost so the CPU-bound shape is visible;
+pass ``--fsync`` to include real ``fsync``. **None of these numbers is a capacity
+claim, a service level, or a statement about any target deployment.** See
+``docs/benchmarks/BENCHMARK_METHOD.md``.
+
+Usage
+-----
+    python -m benchmarks.bench_commit_scaling
+    python benchmarks/bench_commit_scaling.py --lengths 0,1000,4000 --batch 500
+    python benchmarks/bench_commit_scaling.py --json > report.json
+"""
+
+# Copyright (c) 2026 Juan Luna. All rights reserved.
+# Licensed under the GNU Affero General Public License v3 (AGPLv3) OR under a
+# Proprietary Commercial License. See LICENSE and COMMERCIAL.md for terms.
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import secrets
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from aegis.core.crypto_audit import CryptographicAuditLedger
+
+_DEFAULT_LENGTHS = (0, 500, 1_000, 2_000, 4_000, 8_000)
+_DEFAULT_BATCH = 500
+_DEFAULT_K = 3
+
+_REQUEST = b'{"model":"gpt-4o","messages":[{"role":"user","content":"benchmark payload"}]}'
+_RESPONSE = b'{"choices":[{"message":{"role":"assistant","content":"ok"}}]}'
+
+
+def _noop_fsync(_fd: int) -> None:
+    """Remove durable-write cost so the CPU-bound shape of the path is visible."""
+
+
+def measure_at_length(prefill: int, batch: int, k: int, *, real_fsync: bool) -> dict[str, float]:
+    """Time ``batch`` commits made against a chain that already holds ``prefill``.
+
+    Best-of-k is reported, matching ``bench_crypto_audit.py`` and ``bench_mmr.py``
+    (Google Benchmark min methodology), which strips scheduler noise without
+    hiding a systematic cost.
+    """
+    key = secrets.token_hex(32)
+    latencies: list[float] = []
+    for trial in range(k):
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = CryptographicAuditLedger(
+                persistence_path=str(Path(tmp) / f"scaling_{trial}.wal.jsonl"),
+                signing_key=key,
+                fsync_fn=None if real_fsync else _noop_fsync,
+            )
+            try:
+                for i in range(prefill):
+                    ledger.commit_forensic(
+                        state_id=f"prefill-{trial}-{i}",
+                        request_bytes=_REQUEST,
+                        response_bytes=_RESPONSE,
+                    )
+                start = time.perf_counter()
+                for i in range(batch):
+                    ledger.commit_forensic(
+                        state_id=f"measured-{trial}-{i}",
+                        request_bytes=_REQUEST,
+                        response_bytes=_RESPONSE,
+                    )
+                elapsed = time.perf_counter() - start
+            finally:
+                ledger.close()
+        latencies.append(elapsed / batch)
+    best = min(latencies)
+    return {
+        "best_us_per_commit": best * 1_000_000,
+        "mean_us_per_commit": statistics.mean(latencies) * 1_000_000,
+        "best_commits_per_second": 1.0 / best,
+    }
+
+
+def run_benchmark(
+    lengths: tuple[int, ...] = _DEFAULT_LENGTHS,
+    batch: int = _DEFAULT_BATCH,
+    k: int = _DEFAULT_K,
+    *,
+    real_fsync: bool = False,
+    emit_json: bool = False,
+) -> dict[str, Any]:
+    results: dict[str, Any] = {
+        "benchmark": "commit_scaling",
+        "environment": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "processor": platform.processor() or "unknown",
+        },
+        "parameters": {
+            "prefill_lengths": list(lengths),
+            "measured_batch": batch,
+            "trials": k,
+            "fsync": "real" if real_fsync else "no-op seam",
+        },
+        "boundary": (
+            "In-process commit path only. Excludes network, provider, request "
+            "parsing, admission control and response handling. Not a capacity "
+            "claim, service level, or statement about any target deployment."
+        ),
+        "measurements": [],
+    }
+
+    if not emit_json:
+        separator = "=" * 72
+        print(f"\n{separator}", file=sys.stderr)
+        print("COMMIT-COST SCALING — per-commit latency vs. existing chain length", file=sys.stderr)
+        print(separator, file=sys.stderr)
+        print(f"  Measured batch:  {batch:,} commits at each length", file=sys.stderr)
+        print(f"  Trials:          k={k} (best-of-k reported)", file=sys.stderr)
+        print(
+            f"  fsync:           {'real' if real_fsync else 'no-op seam (durability excluded)'}",
+            file=sys.stderr,
+        )
+        print(file=sys.stderr)
+        print(
+            f"  {'prior leaves':>14}{'µs/commit':>14}{'commits/s':>14}{'vs. first':>12}",
+            file=sys.stderr,
+        )
+        print("  " + "-" * 52, file=sys.stderr)
+
+    baseline: float | None = None
+    for prefill in lengths:
+        measured = measure_at_length(prefill, batch, k, real_fsync=real_fsync)
+        if baseline is None:
+            baseline = measured["best_us_per_commit"]
+        ratio = measured["best_us_per_commit"] / baseline if baseline else float("nan")
+        results["measurements"].append(
+            {
+                "prior_leaves": prefill,
+                "best_us_per_commit": round(measured["best_us_per_commit"], 3),
+                "mean_us_per_commit": round(measured["mean_us_per_commit"], 3),
+                "best_commits_per_second": round(measured["best_commits_per_second"], 1),
+                "ratio_to_shortest_chain": round(ratio, 3),
+            }
+        )
+        if not emit_json:
+            print(
+                f"  {prefill:>14,}"
+                f"{measured['best_us_per_commit']:>14.1f}"
+                f"{measured['best_commits_per_second']:>14,.0f}"
+                f"{ratio:>11.2f}x",
+                file=sys.stderr,
+                flush=True,
+            )
+
+    if not emit_json:
+        print(file=sys.stderr)
+        print(
+            "  A flat 'vs. first' column means per-commit cost is independent of\n"
+            "  chain length. A rising column means the commit path does work\n"
+            "  proportional to the number of leaves already committed.",
+            file=sys.stderr,
+        )
+        print(file=sys.stderr)
+
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--lengths",
+        default=",".join(str(value) for value in _DEFAULT_LENGTHS),
+        help="Comma-separated chain lengths to prefill before measuring.",
+    )
+    parser.add_argument("--batch", type=int, default=_DEFAULT_BATCH)
+    parser.add_argument("--k", type=int, default=_DEFAULT_K)
+    parser.add_argument(
+        "--fsync",
+        action="store_true",
+        help="Use real fsync instead of the no-op seam (much slower).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the report as JSON on stdout.")
+    args = parser.parse_args()
+
+    lengths = tuple(int(value) for value in args.lengths.split(",") if value.strip())
+    report = run_benchmark(lengths, args.batch, args.k, real_fsync=args.fsync, emit_json=args.json)
+    if args.json:
+        json.dump(report, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/bench_commit_scaling.py
+++ b/benchmarks/bench_commit_scaling.py
@@ -70,29 +70,30 @@ def measure_at_length(prefill: int, batch: int, k: int, *, real_fsync: bool) -> 
     key = secrets.token_hex(32)
     latencies: list[float] = []
     for trial in range(k):
-        with tempfile.TemporaryDirectory() as tmp:
-            ledger = CryptographicAuditLedger(
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            CryptographicAuditLedger(
                 persistence_path=str(Path(tmp) / f"scaling_{trial}.wal.jsonl"),
                 signing_key=key,
                 fsync_fn=None if real_fsync else _noop_fsync,
-            )
-            try:
-                for i in range(prefill):
-                    ledger.commit_forensic(
-                        state_id=f"prefill-{trial}-{i}",
-                        request_bytes=_REQUEST,
-                        response_bytes=_RESPONSE,
-                    )
-                start = time.perf_counter()
-                for i in range(batch):
-                    ledger.commit_forensic(
-                        state_id=f"measured-{trial}-{i}",
-                        request_bytes=_REQUEST,
-                        response_bytes=_RESPONSE,
-                    )
-                elapsed = time.perf_counter() - start
-            finally:
-                ledger.close()
+            ) as ledger,
+        ):
+            for i in range(prefill):
+                ledger.commit_forensic(
+                    state_id=f"prefill-{trial}-{i}",
+                    request_bytes=_REQUEST,
+                    response_bytes=_RESPONSE,
+                )
+            start = time.perf_counter()
+            for i in range(batch):
+                ledger.commit_forensic(
+                    state_id=f"measured-{trial}-{i}",
+                    request_bytes=_REQUEST,
+                    response_bytes=_RESPONSE,
+                )
+            # Taken before the ledger closes, so the timed region excludes the
+            # final flush and fsync that `__exit__` performs.
+            elapsed = time.perf_counter() - start
         latencies.append(elapsed / batch)
     best = min(latencies)
     return {

--- a/docs/benchmarks/BENCHMARK_METHOD.md
+++ b/docs/benchmarks/BENCHMARK_METHOD.md
@@ -26,6 +26,7 @@ A number without these four things is not a measurement:
 | Statement coverage | `coverage.py` over the suite | Branch coverage; whether tests assert anything meaningful |
 | Test suite outcome | `pytest -q` | Environments where optional backends are absent produce skips |
 | Background dispatch | Microbenchmark of the dispatch path | Everything else: upstream, network, storage, serialization |
+| Commit-cost scaling | `benchmarks/bench_commit_scaling.py` — per-commit latency at increasing chain lengths | Network, provider, request handling, and (by default) durable-write cost; reports the shape of the curve, not a throughput figure |
 | Native MMR operations | Rust criterion benchmarks | Python interop overhead |
 | Backpressure under injected `fsync` delay | Local harness with a seam | Real storage behaviour, real network, real provider |
 | WAF corpus | Pinned corpus replay | Traffic outside the corpus |
@@ -106,6 +107,9 @@ python tools/security/run_waf_corpus.py
 
 # Rust benchmarks
 cd aegis_rust_v2 && cargo bench
+
+# Commit-cost scaling
+python -m benchmarks.bench_commit_scaling --json
 ```
 
 Record your environment alongside any result. A number without its environment is not reproducible, and an irreproducible number is not evidence.

--- a/docs/formal/FORMAL_VERIFICATION_LIMITS.md
+++ b/docs/formal/FORMAL_VERIFICATION_LIMITS.md
@@ -24,8 +24,11 @@ Separating the limits from the description makes it harder to cite the result wi
 | `specs/AegisVerification.lean` | Lean 4 | Mechanised theorem |
 | `specs/aegis_invariants.smt2` | Z3 | Invariant satisfiability |
 | `specs/aegis_stream_buffer.smt2` | Z3 | Per-stream retained-byte arithmetic |
+| `aegis_rust_v2/src/wal.rs` `mod verification` | Kani | WAL frame-bounds arithmetic |
 
-CI gate: `scripts/verify_formal_artifacts.sh`. Toolchain: Lean 4.33.0, TLA+ built from a pinned revision, Z3 from the distribution package.
+CI gates: `scripts/verify_formal_artifacts.sh` (Z3, Lean, TLC) and the `Kani Model Checking` job (`cargo kani`). Toolchain: Lean 4.33.0, TLA+ built from a pinned revision, Z3 from the distribution package, Kani 0.67.0.
+
+The Kani harnesses differ in kind from the others and the difference matters when citing them. They run against the **actual functions in `wal.rs`**, not against a separately written abstraction, so for those two functions the refinement gap described in [§ 4](#not-a-refinement-proof) does not apply. That is a narrow exemption: it covers the frame-bounds arithmetic and nothing else in the file.
 
 ## 3. What is established
 
@@ -36,17 +39,29 @@ Within the declared bounds, the models preserve:
 - **Session-to-ledger binding** — session state and ledger records stay associated as modelled.
 - **Per-stream byte arithmetic** — retained bytes stay within the modelled bound `R_max = 4W + Q + E + P`.
 
-**Falsification conditions:** a Z3 result other than `unsat`, a Lean type-check failure, or a TLC counterexample within the configured bounds. Any of those falsifies the corresponding claim, and the CI gate fails.
+Kani additionally establishes, over the whole `usize` domain rather than within a bound, that `header_range` and `payload_range` in `aegis_rust_v2/src/wal.rs`:
+
+- return a byte range inside the supplied `limit` whenever they return one, and refuse otherwise;
+- never overflow, so no arithmetic wraps into an apparently valid range;
+- never treat a zero-length payload — the recovery terminator — as a frame;
+- always advance the cursor strictly, which is what makes the `read_all` and `scan_write_pos` walks terminate on arbitrary mapped bytes;
+- produce header and payload ranges that do not overlap.
+
+Because every slice taken during a frame walk is bounded through those two functions, an out-of-bounds index during a walk would require one of these properties to fail.
+
+**Falsification conditions:** a Z3 result other than `unsat`, a Lean type-check failure, a TLC counterexample within the configured bounds, or a Kani counterexample. Any of those falsifies the corresponding claim, and the CI gate fails.
 
 ## 4. What is not established
 
 ### Not a refinement proof
 
-The models are abstractions written separately from the code. **Nothing mechanically connects a model to the Python or Rust that runs.**
+The TLA+, Lean and Z3 artifacts are abstractions written separately from the code. **Nothing mechanically connects those models to the Python or Rust that runs.**
 
-A discrepancy between the model and the implementation is invisible to every tool here. The model can be correct and the implementation wrong, and every check still passes.
+A discrepancy between such a model and the implementation is invisible to those tools. The model can be correct and the implementation wrong, and every check still passes.
 
 This is the single most important limitation. A reader who takes "formally verified" to mean the code was proven correct has misunderstood by a wide margin.
+
+The Kani harnesses are the one exception, and they are exactly as narrow as they look: they check two real functions in `wal.rs` over all inputs. They establish nothing about `append`, `open`, `read_all` or `scan_write_pos` as wholes, and nothing about the mapping those functions produce ranges into.
 
 ### Bounded, not exhaustive
 
@@ -66,7 +81,9 @@ The models say nothing about:
 | Network | Partitions, reordering, client disconnects |
 | Concurrency in the real runtime | Python's actual threading and async behaviour |
 | Cryptographic strength | The models treat primitives as abstract |
-| The Rust extension | Not modelled |
+| The Rust extension | Only the two WAL frame-bounds functions are checked; nothing else in the crate is modelled |
+| The memory mapping itself | Kani cannot model `mmap`, `flush_range`, or the filesystem, so durability, crash consistency, torn writes, and the invariant that `capacity` equals the mapped length are all outside it |
+| Concurrent `append` | The mutex and `write_pos` ordering are argued in code comments and exercised by a unit test, not proven |
 | Any deployment | Configuration, scale, operations |
 
 ### Nothing about security properties as a whole
@@ -79,6 +96,10 @@ The models cover specific ordering and arithmetic invariants. They do not model 
 
 > Bounded TLA+/TLC models check that commit-before-emission and append-only ledger prefixes hold within the configured state space, and a Z3 encoding checks per-stream retained-byte arithmetic. These are abstractions, not refinement proofs of the implementation.
 
+And, for the Kani result specifically:
+
+> Kani proves, over all `usize` inputs, that the two functions bounding every slice in the native WAL's frame walks return only in-bounds ranges, never overflow, and always advance. It does not model the memory mapping, durability, or concurrent appends.
+
 **Not acceptable:**
 
 | Do not say | Why |
@@ -88,17 +109,19 @@ The models cover specific ordering and arithmetic invariants. They do not model 
 | "Proven secure" | No adversary is modelled |
 | "Verified implementation" | The implementation is not what was verified |
 | "Exhaustively checked" | Bounded state space |
+| "The WAL is memory-safe" | Two arithmetic functions are proven; the mapping, the flush path and the concurrency are not |
+| "Proven crash-safe" | Kani models no filesystem and no power loss |
 
 ## 6. What would strengthen this
 
 For a reviewer assessing how much weight to give these artifacts, the honest ranking of what is missing:
 
-1. **A refinement relation** connecting a model to the implementation. This is the gap that matters most and is the hardest to close.
+1. **A refinement relation** connecting a model to the implementation. This is the gap that matters most and is the hardest to close. The Kani harnesses sidestep it for two functions by checking the real code, which suggests the achievable direction: verify more real functions rather than write more abstractions.
 2. **Adversary modelling**, so the results say something about security rather than only about ordering.
 3. **Wider bounds**, with the state-space size recorded so a reader can judge coverage.
 4. **Property-based testing** against the same invariants, executed on the real implementation — a weaker but achievable bridge between model and code.
 
-None is in progress. See [Roadmap](../../ROADMAP.md).
+Only the narrow Kani exemption in item 1 exists today; the rest is not in progress. See [Roadmap](../../ROADMAP.md).
 
 ---
 

--- a/evidence/INDEX.md
+++ b/evidence/INDEX.md
@@ -39,6 +39,7 @@ The post-merge record is the current locator for the v4 **source baseline**. Its
 | [`commercial_phase2_streaming_benchmark.json`](commercial_phase2_streaming_benchmark.json) | Post-v3.1.0 local source benchmark | Bounded local workload; excludes network and durable-WAL latency and is not production capacity. |
 | [`commercial_phase2_dashboard_qa.md`](commercial_phase2_dashboard_qa.md) | Post-v3.1.0 local dashboard QA | Local source/UI review; not deployment availability, customer telemetry, accessibility certification, or acceptance. |
 | [`apex_workstreams_9_11_gate_2026-08-24.md`](apex_workstreams_9_11_gate_2026-08-24.md) | 2026-08-24 source gate record | Retains its own stated scope and limitations; not registry publication or external assurance. |
+| [`commit_scaling_measurement_2026-09-03.md`](commit_scaling_measurement_2026-09-03.md) | 2026-09-03 in-process microbenchmark of the ledger commit path | One container, one date. Excludes network, provider, and (by default) durable-write cost; establishes the shape of the per-commit cost curve, not throughput capacity or any service level. |
 
 ## Integrity sidecars and manifests
 

--- a/evidence/commit_scaling_measurement_2026-09-03.md
+++ b/evidence/commit_scaling_measurement_2026-09-03.md
@@ -1,0 +1,96 @@
+# Commit-Cost Scaling Measurement — 2026-09-03
+
+> **Nature of this document.** This records one in-process microbenchmark taken in a
+> single ephemeral Linux container on 2026-09-03. It is not a capacity claim, a service
+> level, an end-to-end latency figure, or a statement about any target deployment. It
+> follows the citation rules in [`docs/benchmarks/BENCHMARK_METHOD.md`](../docs/benchmarks/BENCHMARK_METHOD.md):
+> artifact, environment, date, boundary.
+
+## [EPISTEMIC_HEADER]
+
+| Field | Value |
+|---|---|
+| Measurement type | In-process microbenchmark of `CryptographicAuditLedger.commit_forensic` |
+| Question | Does per-commit cost depend on the number of leaves already committed? |
+| Baseline measured ("before") | `ef71920a431c5d1950274f8946264a41e97b24f4` |
+| Change measured ("after") | Same commit with the MMR rollback change in the working tree |
+| Environment | Ephemeral container; `Linux-6.18.44-fc-v24-x86_64-with-glibc2.39`; CPython 3.11.15 (GCC 13.3.0); 4 logical CPUs |
+| Harness | `benchmarks/bench_commit_scaling.py` |
+| Confidence | High for the shape of the curve; none asserted for any deployment |
+| Falsification | Re-run the commands below on the same commit and observe a different curve |
+
+## What was measured
+
+`commit_forensic` appends a leaf to the MMR before it knows whether signing and WAL
+persistence will succeed, and reverts the MMR if either fails. The revert was a
+`copy.deepcopy` of the entire accumulator, taken on **every** commit — including the
+successful ones, which are the overwhelming majority. The copy is O(number of leaves),
+so per-commit cost grew with the length of the chain.
+
+The change replaces the copy with `MerkleMountainRange.checkpoint()` /
+`rollback_to()`: a token holding the append-only lengths plus the live peak node
+objects, which is O(log n) to take and O(log n) to apply.
+
+## Result
+
+200 measured commits at each chain length, best of 2 trials, no-op `fsync` seam:
+
+| Prior leaves | Before (µs/commit) | After (µs/commit) | Ratio |
+|---|---|---|---|
+| 0 | 1,708.2 | 378.7 | 4.5× |
+| 500 | 7,827.1 | 328.9 | 23.8× |
+| 1,000 | 14,618.7 | 394.7 | 37.0× |
+| 2,000 | 30,153.9 | 361.7 | 83.4× |
+
+Normalised to each run's own shortest chain, the "before" curve rises `1.00× → 4.58× →
+8.56× → 17.65×` while the "after" curve stays within measurement noise of flat
+(`1.00× → 0.87× → 1.04× → 0.95×`).
+
+A separate run of the same harness on the changed code over a wider range
+(`0, 500, 1000, 2000, 4000, 8000` prior leaves, 300 commits, best of 3) reported
+`1.00× → 1.09× → 1.05× → 1.00× → 1.07× → 1.12×`. The residual rise at 8,000 tracks the
+growing WAL file, not the accumulator.
+
+**Interpretation.** Per-commit cost is now independent of chain length over the range
+measured. The absolute microsecond figures are properties of this container and this
+harness only.
+
+## Correctness evidence accompanying the change
+
+The optimisation is only sound if the rollback is exact. `tests/test_mmr_rollback.py`
+compares `rollback_to` against a `copy.deepcopy` restore across leaf counts straddling
+every power of two up to 64, checks peak/node object aliasing and cleared parent
+pointers, and asserts that a ledger whose commit failed at signing or at WAL persistence
+produces the same MMR — node for node — as a ledger that never attempted the failed
+commit.
+
+## Boundary
+
+- In-process commit path only. **Excludes** network, upstream provider, request parsing,
+  admission control, WAF evaluation, rate limiting, and response handling.
+- The default harness installs a no-op `fsync_fn`, so **durable-write cost is excluded**.
+  Pass `--fsync` to include it; real `fsync` dominates and hides the CPU-bound shape,
+  which is why it is off by default here.
+- Best-of-k reporting strips scheduler noise; it does not model tail latency.
+- One container, one CPU model, one Python build, one date. Nothing here establishes
+  throughput capacity, a service level, multi-replica behaviour, behaviour on network
+  storage, or sustained load.
+- No production-scale measurement exists for this repository.
+
+## Reproduction
+
+```bash
+# "after" — current source
+python -m benchmarks.bench_commit_scaling --lengths 0,500,1000,2000 --batch 200 --k 2 --json
+
+# "before" — the same harness against the pre-change rollback strategy
+git stash push aegis/core/mmr.py aegis/core/crypto_audit.py
+python -m benchmarks.bench_commit_scaling --lengths 0,500,1000,2000 --batch 200 --k 2 --json
+git stash pop
+```
+
+Once the change is merged, reproduce "before" by checking the two files out at the
+parent commit instead of stashing.
+
+Preserve the raw JSON, the environment manifest, the source commit and the UTC
+timestamp with every rerun.

--- a/evidence/commit_scaling_measurement_2026-09-03.md.sha256
+++ b/evidence/commit_scaling_measurement_2026-09-03.md.sha256
@@ -1,0 +1,1 @@
+59738c2fc3939e67aa5469719905dd02a62eaf04a129cf2d0d72a062813525bc  commit_scaling_measurement_2026-09-03.md

--- a/tests/test_crypto_audit_rollover.py
+++ b/tests/test_crypto_audit_rollover.py
@@ -1,0 +1,276 @@
+"""
+tests/test_crypto_audit_rollover.py — chain integrity across memory-window rollover.
+
+The in-memory chain is a ``deque(maxlen=max_memory_nodes)``. Once it is full,
+every append silently evicts the oldest node. ``verify_integrity`` walks the
+window checking ``node[i].prev_hash == node[i-1].node_hash``, so the very first
+node in the window has no in-memory predecessor to link against: its
+``prev_hash`` points at a node that was evicted.
+
+``_append_memory_node`` closes that hole by recording the evicted node's hash in
+``_window_anchor_hash`` *before* the eviction happens, and ``verify_integrity``
+uses that anchor as the expected predecessor for index 0. These tests pin the
+mechanism, in both directions — integrity holds across many rollovers, and a
+break at the window boundary is still detected rather than absorbed by the
+anchor.
+
+The 100,000-node sweep is marked ``slow``; the boundary and detection tests run
+in the default suite at small window sizes, where the same code path executes.
+"""
+
+# Copyright (c) 2026 Juan Luna. All rights reserved.
+# Licensed under the GNU Affero General Public License v3 (AGPLv3) OR under a
+# Proprietary Commercial License. See LICENSE and COMMERCIAL.md for terms.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aegis.core.crypto_audit import CryptographicAuditLedger
+from aegis.core.mmr import MerkleMountainRange
+
+GENESIS = "0" * 64
+REQUEST = b'{"messages":[{"role":"user","content":"hello"}]}'
+RESPONSE = b'{"choices":[{"message":{"content":"hi"}}]}'
+
+
+def _ledger(path: Path, window: int, **kwargs: Any) -> CryptographicAuditLedger:
+    """A ledger with fsync disabled — durability is covered by its own tests."""
+    return CryptographicAuditLedger(
+        persistence_path=str(path),
+        signing_key="k" * 32,
+        max_memory_nodes=window,
+        fsync_fn=lambda fd: None,
+        **kwargs,
+    )
+
+
+def _commit(ledger: CryptographicAuditLedger, index: int) -> str:
+    node = ledger.commit_forensic(
+        state_id=f"req-{index}",
+        request_bytes=REQUEST,
+        response_bytes=RESPONSE,
+        model="m",
+        endpoint="chat.completions",
+    )
+    return node.node_hash
+
+
+# ── Anchor bookkeeping ───────────────────────────────────────────────────────
+
+
+def test_anchor_is_genesis_until_the_window_fills(tmp_path: Path) -> None:
+    """No eviction has happened, so index 0 must still link to genesis."""
+    ledger = _ledger(tmp_path / "audit.jsonl", window=8)
+    for i in range(8):
+        _commit(ledger, i)
+
+    assert len(ledger.chain) == 8
+    assert ledger.window_anchor_hash == GENESIS
+    assert ledger.chain[0].prev_hash == GENESIS
+    assert ledger.verify_integrity() == (True, None)
+    ledger.close()
+
+
+def test_anchor_tracks_the_most_recently_evicted_node(tmp_path: Path) -> None:
+    """After each eviction the anchor must equal the evicted node's hash.
+
+    Checked on every commit past the boundary rather than only at the end, so
+    an off-by-one that self-corrects on the next append cannot hide.
+    """
+    window = 8
+    ledger = _ledger(tmp_path / "audit.jsonl", window=window)
+    hashes = [_commit(ledger, i) for i in range(window)]
+
+    for i in range(window, window + 25):
+        hashes.append(_commit(ledger, i))
+        evicted = len(hashes) - window - 1
+        assert ledger.window_anchor_hash == hashes[evicted], (
+            f"anchor should name node {evicted} after committing node {i}"
+        )
+        assert ledger.chain[0].prev_hash == ledger.window_anchor_hash
+        assert ledger.verify_integrity() == (True, None)
+    ledger.close()
+
+
+@pytest.mark.parametrize("window", [1, 2, 3, 8, 64])
+def test_integrity_holds_across_many_rollovers(tmp_path: Path, window: int) -> None:
+    """Integrity must survive repeated full turnovers of the window.
+
+    ``window=1`` is the degenerate case where every single append evicts the
+    node committed immediately before it.
+    """
+    ledger = _ledger(tmp_path / "audit.jsonl", window=window)
+    for i in range(window * 10 + 3):
+        _commit(ledger, i)
+
+    assert len(ledger.chain) == window
+    assert ledger.verify_integrity() == (True, None)
+    ledger.close()
+
+
+# ── Detection is preserved, not absorbed ─────────────────────────────────────
+
+
+def test_node_dropped_at_the_window_boundary_is_detected(tmp_path: Path) -> None:
+    """Deleting the oldest in-window node must break verification.
+
+    Every node left behind is still individually self-consistent — the deleted
+    one is simply gone — so the per-node hash check cannot catch this. Only the
+    ``prev_hash == anchor`` comparison at index 0 can, which makes this the
+    sharpest available test of the anchor: an implementation that skipped index
+    0, or that recomputed the expected predecessor from the node itself, would
+    accept a silently truncated window.
+    """
+    ledger = _ledger(tmp_path / "audit.jsonl", window=8)
+    for i in range(20):
+        _commit(ledger, i)
+    assert ledger.verify_integrity() == (True, None)
+
+    ledger.chain.popleft()
+    for index, node in enumerate(ledger.chain):
+        assert node.node_hash == node.__creation_hash__, (
+            f"node {index} was mutated; this test must exercise the link check alone"
+        )
+
+    ok, index = ledger.verify_integrity()
+    assert ok is False
+    assert index == 0
+    ledger.close()
+
+
+def test_prev_hash_rewritten_at_the_window_boundary_is_detected(tmp_path: Path) -> None:
+    """Repointing the first node's predecessor must not verify."""
+    ledger = _ledger(tmp_path / "audit.jsonl", window=8)
+    for i in range(20):
+        _commit(ledger, i)
+
+    ledger.chain[0].prev_hash = "a" * 64
+    ok, index = ledger.verify_integrity()
+    assert ok is False
+    assert index == 0
+    ledger.close()
+
+
+def test_tampered_anchor_is_detected(tmp_path: Path) -> None:
+    """Rewriting the anchor must invalidate the window it anchors."""
+    ledger = _ledger(tmp_path / "audit.jsonl", window=8)
+    for i in range(20):
+        _commit(ledger, i)
+
+    ledger._window_anchor_hash = "b" * 64
+    assert ledger.verify_integrity() == (False, 0)
+    ledger.close()
+
+
+def test_tampered_mid_window_node_is_detected(tmp_path: Path) -> None:
+    """Rollover must not weaken detection anywhere else in the window."""
+    ledger = _ledger(tmp_path / "audit.jsonl", window=8)
+    for i in range(20):
+        _commit(ledger, i)
+
+    ledger.chain[4].entropy = 99.0
+    ok, index = ledger.verify_integrity()
+    assert ok is False
+    assert index == 4
+    ledger.close()
+
+
+# ── Durable chain outlives the window ────────────────────────────────────────
+
+
+def test_wal_retains_every_node_the_window_evicted(tmp_path: Path) -> None:
+    """Eviction is a memory bound, not retention: the WAL keeps the full chain.
+
+    Reopening with a window large enough to hold everything must reconstruct a
+    chain that links back to genesis with no anchor in play.
+    """
+    path = tmp_path / "audit.jsonl"
+    ledger = _ledger(path, window=8)
+    for i in range(60):
+        _commit(ledger, i)
+    ledger.close()
+
+    reopened = _ledger(path, window=1024)
+    assert len(reopened.chain) == 60
+    assert reopened.window_anchor_hash == GENESIS
+    assert reopened.chain[0].prev_hash == GENESIS
+    assert reopened.verify_integrity() == (True, None)
+    assert reopened._mmr.get_leaf_count() == 60
+    reopened.close()
+
+
+def test_replay_into_a_small_window_reestablishes_the_anchor(tmp_path: Path) -> None:
+    """Replay evicts through the same path, so it must rebuild the anchor too.
+
+    A restart that left the anchor at genesis would report a false integrity
+    violation on the first node of the reloaded window.
+    """
+    path = tmp_path / "audit.jsonl"
+    ledger = _ledger(path, window=1024)
+    hashes = [_commit(ledger, i) for i in range(60)]
+    ledger.close()
+
+    reopened = _ledger(path, window=8)
+    assert len(reopened.chain) == 8
+    assert reopened.window_anchor_hash == hashes[60 - 8 - 1]
+    assert reopened.verify_integrity() == (True, None)
+    reopened.close()
+
+
+# ── Full-scale sweep ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.slow
+def test_integrity_across_one_hundred_thousand_nodes(tmp_path: Path) -> None:
+    """Commit 100,000 nodes through a 512-node window and verify the result.
+
+    That is 194 complete turnovers of the in-memory window. Signature checking
+    dominates a full ``verify_integrity`` sweep, so the sweep runs once at the
+    end rather than per commit; anchor bookkeeping is checked on every eviction
+    instead, which is the part rollover can break.
+
+    The MMR is also asserted: the accumulator is unbounded and must still hold
+    all 100,000 leaves, with proofs that verify against the live root long after
+    the corresponding nodes left memory.
+    """
+    total = 100_000
+    window = 512
+    ledger = _ledger(tmp_path / "audit.jsonl", window=window)
+
+    previous_hash = GENESIS
+    anchor_checks = 0
+    for i in range(total):
+        node = ledger.commit_forensic(
+            state_id=f"req-{i}",
+            request_bytes=REQUEST,
+            response_bytes=RESPONSE,
+            model="m",
+            endpoint="chat.completions",
+        )
+        assert node.prev_hash == previous_hash
+        previous_hash = node.node_hash
+        if i >= window:
+            # Every append past the boundary evicts exactly one node, so the
+            # anchor must equal the hash the current head links back to.
+            assert ledger.window_anchor_hash == ledger.chain[0].prev_hash
+            anchor_checks += 1
+
+    assert anchor_checks == total - window
+    assert len(ledger.chain) == window
+    assert ledger.window_anchor_hash != GENESIS
+    assert ledger.verify_integrity() == (True, None)
+
+    mmr = ledger._mmr
+    assert mmr.get_leaf_count() == total
+    root = mmr.get_root_hash()
+    for index in (0, 1, window, total // 2, total - window - 1, total - 1):
+        leaf_hash = mmr.nodes[mmr._leaf_node_indices[index]].hash
+        proof = mmr.get_portable_inclusion_proof(index)
+        assert MerkleMountainRange.verify_portable_inclusion_hash(leaf_hash, proof, root), (
+            f"leaf {index} does not prove inclusion in the {total}-leaf root"
+        )
+    ledger.close()

--- a/tests/test_mmr_parity.py
+++ b/tests/test_mmr_parity.py
@@ -62,3 +62,79 @@ def test_rust_python_leaf_count_parity() -> None:
         py.add_leaf(f"x-{i}".encode())
         ru.add_leaf(f"x-{i}".encode())
     assert int(ru.get_leaf_count()) == py._leaf_count == 10
+
+
+@pytest.mark.parametrize("leaf_count", [1, 2, 3, 5, 8, 13, 21, 34])
+def test_python_proof_verifies_against_the_rust_root(leaf_count: int) -> None:
+    """Every Python-generated proof must verify against the Rust-reported root.
+
+    This is the exact composition ``RustBackedMMR`` ships: ``get_root_hash``
+    returns the Rust root while ``get_portable_inclusion_proof`` is served from
+    the Python replica. Root parity alone does not cover it, because a proof
+    also carries the peak set and the sibling path. If the two implementations
+    ever diverge in peak ordering or in the bytes fed to the compression
+    function, this fails where a root-only comparison would still pass.
+    """
+    py = MerkleMountainRange()
+    ru = _rust_mmr()
+    leaves = [f"leaf-{i}".encode() for i in range(leaf_count)]
+    for leaf in leaves:
+        py.add_leaf(leaf)
+        ru.add_leaf(leaf)
+
+    rust_root = ru.get_root_hash()
+    for index, leaf in enumerate(leaves):
+        proof = py.get_portable_inclusion_proof(index)
+        assert MerkleMountainRange.verify_portable_inclusion(leaf, proof, rust_root), (
+            f"Python proof for leaf {index} does not verify against the Rust root "
+            f"at leaf_count={leaf_count}"
+        )
+
+
+def test_rust_backed_mmr_serves_proofs_that_verify_against_its_own_root() -> None:
+    """The shipped hybrid must be self-consistent end to end.
+
+    ``RustBackedMMR`` is only constructed when the extension is importable, so
+    it is reached through the module rather than imported at module scope.
+    """
+    from aegis.core import mmr as mmr_mod
+
+    hybrid_cls = getattr(mmr_mod, "RustBackedMMR", None)
+    if hybrid_cls is None:
+        pytest.skip("RustBackedMMR is not defined in this build")
+
+    hybrid = hybrid_cls()
+    leaves = [f"hybrid-{i}".encode() for i in range(24)]
+    for leaf in leaves:
+        hybrid.add_leaf(leaf)
+
+    root = hybrid.get_root_hash()
+    for index, leaf in enumerate(leaves):
+        proof = hybrid.get_portable_inclusion_proof(index)
+        assert proof.root == root, (
+            f"hybrid proof root {proof.root} disagrees with the served root {root}"
+        )
+        assert MerkleMountainRange.verify_portable_inclusion(leaf, proof, root)
+
+
+def test_rust_and_python_agree_on_the_declared_wire_algorithm() -> None:
+    """The proof's ``algorithm`` field must describe the hash actually used.
+
+    ``verify_portable_inclusion_hash`` rejects any value other than
+    ``sha256-asciihex`` and recomputes with SHA-256 over ASCII hex. Changing
+    either implementation's digest or its concatenation format without changing
+    this literal — and the verifier alongside it — would invalidate every proof
+    already issued, so the coupling is pinned here.
+    """
+    py = MerkleMountainRange()
+    ru = _rust_mmr()
+    for i in range(7):
+        py.add_leaf(f"wire-{i}".encode())
+        ru.add_leaf(f"wire-{i}".encode())
+
+    proof = py.get_portable_inclusion_proof(3)
+    assert proof.version == "aegis-mmr-inclusion-v1"
+    assert proof.algorithm == "sha256-asciihex"
+    assert proof.root == ru.get_root_hash()
+    assert all(len(peak.hash) == 64 for peak in proof.peaks)
+    assert all(len(step.sibling_hash) == 64 for step in proof.path)

--- a/tests/test_mmr_rollback.py
+++ b/tests/test_mmr_rollback.py
@@ -1,0 +1,308 @@
+"""
+tests/test_mmr_rollback.py — exact MMR append rollback and ledger fail-closed revert.
+
+``CryptographicAuditLedger`` mutates its MMR before it knows whether the commit
+will succeed, then reverts when signing or WAL persistence fails. That revert
+used to be a ``copy.deepcopy`` of the whole accumulator taken on *every* commit,
+which made commit cost grow with the length of the chain. It is now an O(log n)
+checkpoint token.
+
+The optimisation is only sound if the rollback is byte-for-byte exact, so these
+tests pin two things that were previously unasserted:
+
+1. ``rollback_to`` reproduces the state a deep copy would have restored — the
+   node list, the peak list, peak/node object aliasing, the leaf bookkeeping,
+   the root, and every subsequent inclusion proof.
+2. The ledger actually reverts its MMR when signing or persistence fails, so a
+   failed commit leaves no leaf behind and the next successful commit produces
+   the same root it would have produced had the failure never happened.
+"""
+
+# Copyright (c) 2026 Juan Luna. All rights reserved.
+# Licensed under the GNU Affero General Public License v3 (AGPLv3) OR under a
+# Proprietary Commercial License. See LICENSE and COMMERCIAL.md for terms.
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aegis.core.crypto_audit import CryptographicAuditLedger
+from aegis.core.mmr import MerkleMountainRange
+
+REQUEST = b'{"messages":[{"role":"user","content":"hello"}]}'
+RESPONSE = b'{"choices":[{"message":{"content":"hi"}}]}'
+
+
+def _state(mmr: MerkleMountainRange) -> tuple[Any, ...]:
+    """Full observable state of an MMR, for equality comparison."""
+    return (
+        [dataclasses.astuple(node) for node in mmr.nodes],
+        [dataclasses.astuple(peak) for peak in mmr.peaks],
+        list(mmr._leaf_node_indices),
+        mmr._leaf_count,
+        mmr.get_root_hash(),
+    )
+
+
+def _build(leaf_count: int) -> MerkleMountainRange:
+    mmr = MerkleMountainRange()
+    for i in range(leaf_count):
+        mmr.add_leaf(f"leaf-{i}".encode())
+    return mmr
+
+
+def _ledger(tmp_path: Path, **kwargs: Any) -> CryptographicAuditLedger:
+    return CryptographicAuditLedger(
+        persistence_path=str(tmp_path / "audit.jsonl"),
+        signing_key="k" * 32,
+        fsync_fn=lambda fd: None,
+        **kwargs,
+    )
+
+
+# ── MMR checkpoint / rollback ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("leaf_count", [0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64])
+def test_rollback_matches_deepcopy_restore(leaf_count: int) -> None:
+    """Rollback must land on exactly the state a deep copy would have restored.
+
+    Leaf counts straddle every power of two, because the number of peaks merged
+    by a single append — and therefore the number of ``parent`` pointers the
+    rollback has to clear — is determined by the trailing one-bits of the count.
+    """
+    mmr = _build(leaf_count)
+    expected = _state(copy.deepcopy(mmr))
+
+    checkpoint = mmr.checkpoint()
+    mmr.add_leaf(b"leaf-that-must-not-survive")
+    mmr.rollback_to(checkpoint)
+
+    assert _state(mmr) == expected
+
+
+@pytest.mark.parametrize("leaf_count", [1, 2, 3, 4, 7, 8, 15, 16, 31, 32])
+def test_rollback_restores_peak_node_aliasing(leaf_count: int) -> None:
+    """Peaks must remain the same objects as the nodes they name, with no parent.
+
+    ``get_portable_inclusion_proof`` walks ``node.parent`` to find a leaf's peak
+    and matches it by ``peak.index``. A rollback that left a stale parent
+    pointer, or that replaced a peak with a copy, would produce proofs against
+    a peak the root does not contain.
+    """
+    mmr = _build(leaf_count)
+    checkpoint = mmr.checkpoint()
+    mmr.add_leaf(b"transient")
+    mmr.rollback_to(checkpoint)
+
+    for peak in mmr.peaks:
+        assert mmr.nodes[peak.index] is peak
+        assert peak.parent is None
+
+
+def test_rollback_undoes_many_appends() -> None:
+    """One checkpoint covers an arbitrary run of appends, not just a single one."""
+    mmr = _build(37)
+    reference = _state(copy.deepcopy(mmr))
+
+    checkpoint = mmr.checkpoint()
+    for i in range(50):
+        mmr.add_leaf(f"transient-{i}".encode())
+    mmr.rollback_to(checkpoint)
+
+    assert _state(mmr) == reference
+
+
+def test_appends_after_rollback_match_a_clean_run() -> None:
+    """A rolled-back MMR must be indistinguishable from one that never appended.
+
+    Root equality alone would not catch a corrupted interior node, so every
+    inclusion proof is compared as well.
+    """
+    rolled_back = _build(20)
+    checkpoint = rolled_back.checkpoint()
+    rolled_back.add_leaf(b"transient")
+    rolled_back.rollback_to(checkpoint)
+    for i in range(20, 60):
+        rolled_back.add_leaf(f"leaf-{i}".encode())
+
+    clean = _build(60)
+
+    assert rolled_back.get_root_hash() == clean.get_root_hash()
+    for index in range(60):
+        assert (
+            rolled_back.get_portable_inclusion_proof(index).to_dict()
+            == clean.get_portable_inclusion_proof(index).to_dict()
+        )
+
+
+def test_checkpoint_is_cheap_relative_to_the_structure() -> None:
+    """A checkpoint holds only the peaks, so it stays O(log n), not O(n).
+
+    This is the property the optimisation rests on. Asserting the peak count
+    rather than a wall-clock time keeps the test deterministic on shared CI.
+    """
+    mmr = _build(1024)
+    checkpoint = mmr.checkpoint()
+
+    assert len(checkpoint.peaks) == bin(1024).count("1")
+    assert checkpoint.node_count == len(mmr.nodes)
+    assert checkpoint.leaf_count == 1024
+
+
+def test_rollback_rejects_a_checkpoint_from_another_mmr() -> None:
+    """A checkpoint that is not a prefix of the current state must be refused.
+
+    Silently accepting one would truncate a longer chain to a shorter one — an
+    evidence-destroying outcome that must fail loudly instead.
+    """
+    ahead = _build(10)
+    behind = _build(3)
+    checkpoint = ahead.checkpoint()
+
+    with pytest.raises(ValueError, match="prefix of the current state"):
+        behind.rollback_to(checkpoint)
+
+
+# ── Ledger fail-closed revert ────────────────────────────────────────────────
+
+
+def _boom(*_args: Any, **_kwargs: Any) -> None:
+    raise RuntimeError("induced failure")
+
+
+def _attempt(ledger: CryptographicAuditLedger, commit: str, state_id: str) -> None:
+    """Invoke one of the ledger's commit entry points."""
+    if commit == "commit_forensic":
+        ledger.commit_forensic(state_id=state_id, request_bytes=REQUEST, response_bytes=RESPONSE)
+    elif commit == "commit_state":
+        ledger.commit_state(state_id=state_id, entropy=0.0, payload=REQUEST)
+    else:
+        # The streaming terminal commit carries its own checkpoint site.
+        ledger.commit_forensic_summary(
+            state_id=state_id,
+            request_bytes=REQUEST,
+            response_hash="c" * 64,
+            response_size=len(RESPONSE),
+            response_preview=RESPONSE,
+            terminal_outcome="complete",
+            final_marker_included=True,
+            token_count=3,
+            elapsed_seconds=0.25,
+        )
+
+
+@pytest.mark.parametrize("failing_stage", ["_sign", "_persist_node"])
+@pytest.mark.parametrize("commit", ["commit_forensic", "commit_state", "commit_forensic_summary"])
+def test_failed_commit_leaves_no_leaf_in_the_mmr(
+    tmp_path: Path, failing_stage: str, commit: str
+) -> None:
+    """A commit that fails after the leaf is appended must revert the MMR.
+
+    Both failure points sit between the append and the WAL write, and both
+    checkpoint sites — the request/response commit and the streaming terminal
+    commit — must revert identically, so every combination is pinned.
+    """
+    ledger = _ledger(tmp_path)
+    for i in range(5):
+        ledger.commit_forensic(state_id=f"ok-{i}", request_bytes=REQUEST, response_bytes=RESPONSE)
+
+    root_before = ledger._mmr.get_root_hash()
+    count_before = ledger._mmr.get_leaf_count()
+
+    setattr(ledger, failing_stage, _boom)
+    with pytest.raises(RuntimeError, match="induced failure"):
+        _attempt(ledger, commit, "doomed")
+
+    assert ledger._mmr.get_root_hash() == root_before
+    assert ledger._mmr.get_leaf_count() == count_before
+    ledger.close()
+
+
+@pytest.mark.parametrize("failing_stage", ["_sign", "_persist_node"])
+def test_commit_after_a_failed_commit_matches_an_unbroken_run(
+    tmp_path: Path, failing_stage: str
+) -> None:
+    """The chain must continue as if the failed commit had never been attempted.
+
+    A rollback that merely restored the leaf *count* while leaving a stale
+    interior node would pass the previous test and fail this one.
+    """
+    broken = _ledger(tmp_path / "broken")
+    clean = _ledger(tmp_path / "clean")
+
+    for i in range(8):
+        for ledger in (broken, clean):
+            ledger.commit_forensic(
+                state_id=f"ok-{i}", request_bytes=REQUEST, response_bytes=RESPONSE
+            )
+
+    original = getattr(broken, failing_stage)
+    setattr(broken, failing_stage, _boom)
+    with pytest.raises(RuntimeError):
+        broken.commit_forensic(state_id="doomed", request_bytes=REQUEST, response_bytes=RESPONSE)
+    setattr(broken, failing_stage, original)
+
+    for i in range(8, 20):
+        for ledger in (broken, clean):
+            ledger.commit_forensic(
+                state_id=f"ok-{i}", request_bytes=REQUEST, response_bytes=RESPONSE
+            )
+
+    assert broken._mmr.get_root_hash() == clean._mmr.get_root_hash()
+    assert _state(broken._mmr) == _state(clean._mmr)
+    broken.close()
+    clean.close()
+
+
+def test_failed_commit_writes_no_wal_record(tmp_path: Path) -> None:
+    """A reverted commit must leave no trace in the durable evidence log."""
+    ledger = _ledger(tmp_path)
+    for i in range(3):
+        ledger.commit_forensic(state_id=f"ok-{i}", request_bytes=REQUEST, response_bytes=RESPONSE)
+
+    ledger._sign = _boom  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError):
+        ledger.commit_forensic(state_id="doomed", request_bytes=REQUEST, response_bytes=RESPONSE)
+    ledger.close()
+
+    records = [
+        json.loads(line)
+        for line in (tmp_path / "audit.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    assert [record["state_id"] for record in records] == ["ok-0", "ok-1", "ok-2"]
+
+
+def test_proofs_still_verify_after_a_failed_commit(tmp_path: Path) -> None:
+    """Every committed leaf must still prove inclusion against the live root.
+
+    This is the property a botched rollback would break in the field: the root
+    keeps advancing, but proofs served from the corrupted structure no longer
+    verify against it.
+    """
+    ledger = _ledger(tmp_path)
+    for i in range(6):
+        ledger.commit_forensic(state_id=f"ok-{i}", request_bytes=REQUEST, response_bytes=RESPONSE)
+
+    ledger._persist_node = _boom  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError):
+        ledger.commit_forensic(state_id="doomed", request_bytes=REQUEST, response_bytes=RESPONSE)
+    del ledger._persist_node
+
+    for i in range(6, 12):
+        ledger.commit_forensic(state_id=f"ok-{i}", request_bytes=REQUEST, response_bytes=RESPONSE)
+
+    mmr = ledger._mmr
+    root = mmr.get_root_hash()
+    for index in range(mmr.get_leaf_count()):
+        leaf_hash = mmr.nodes[mmr._leaf_node_indices[index]].hash
+        proof = mmr.get_portable_inclusion_proof(index)
+        assert MerkleMountainRange.verify_portable_inclusion_hash(leaf_hash, proof, root)
+    ledger.close()

--- a/tests/test_proxy_streaming.py
+++ b/tests/test_proxy_streaming.py
@@ -62,6 +62,84 @@ def test_streaming_deidentifier_fails_closed_on_overlong_open_url() -> None:
         deidentifier.feed("https://example.test/" + "a" * 128)
 
 
+def test_streaming_deidentifier_fails_closed_on_uppercase_open_url() -> None:
+    """The URL detector is case-insensitive, so the open-candidate guard must be.
+
+    Searching only for the lowercase marker let an uppercase scheme past the
+    guard entirely — a fail-open on the very grammar the guard exists for.
+    """
+    deidentifier = StreamingDeidentifier(window_chars=64, enable_phi=True)
+    with pytest.raises(StreamingDeidentificationError, match="open URL"):
+        deidentifier.feed("HTTPS://EXAMPLE.TEST/" + "A" * 128)
+
+
+@pytest.mark.parametrize(
+    "opening",
+    [
+        ";4111111111111111=25121010000012345678",
+        "%B4111111111111111^DOE/JOHN^2512101000001",
+        "%b4111111111111111^DOE/JOHN^2512101000001",
+    ],
+)
+def test_streaming_deidentifier_fails_closed_on_overlong_open_track_data(opening: str) -> None:
+    """An unterminated track-1 or track-2 run must still fail closed.
+
+    Lowercase ``%b`` is included because the track-1 detector is
+    case-insensitive; the guard has to search the same way the detector matches.
+    """
+    deidentifier = StreamingDeidentifier(window_chars=64, enable_pci=True)
+    with pytest.raises(StreamingDeidentificationError, match="track-data"):
+        deidentifier.feed(opening + "0" * 200)
+
+
+def test_streaming_deidentifier_fails_closed_on_overlong_open_email() -> None:
+    """An address longer than the window with no whitespace cannot settle."""
+    deidentifier = StreamingDeidentifier(window_chars=64, enable_phi=True)
+    with pytest.raises(StreamingDeidentificationError, match="open email"):
+        deidentifier.feed("a" * 100 + "@example.test" + "b" * 100)
+
+
+@pytest.mark.parametrize(
+    ("label", "text"),
+    [
+        (
+            "semicolon in prose",
+            "We shipped it; " + "the rollout went smoothly across every region today. " * 4,
+        ),
+        (
+            "email mentioned mid-stream",
+            "Please contact our support desk at support@example.test and we will get back "
+            "to you within one business day about the invoice you mentioned earlier.",
+        ),
+        (
+            "email early with a long tail",
+            "support@example.test is the address; " + "and the explanation continues here. " * 4,
+        ),
+        (
+            "at-sign in code",
+            "@dataclass class Config: pass  " + "followed by more explanatory prose here. " * 4,
+        ),
+        (
+            "terminated URL followed by prose",
+            "See https://example.test/docs for details. " + "More prose follows after it. " * 4,
+        ),
+    ],
+)
+def test_streaming_deidentifier_does_not_abort_on_ordinary_prose(label: str, text: str) -> None:
+    """Ordinary text must stream through, whole or byte-chunked.
+
+    Each of these aborted the stream before the open-candidate guards were
+    tightened to test for a viable prefix of the detector they guard. A raised
+    ``StreamingDeidentificationError`` reaches the client as a
+    ``privacy_failure`` terminal outcome, so a false positive here is a
+    user-visible failure on text containing nothing sensitive.
+    """
+    for chunks in ([text], [text[i : i + 7] for i in range(0, len(text), 7)]):
+        deidentifier = StreamingDeidentifier(window_chars=128, enable_phi=True, enable_pci=True)
+        output = "".join(deidentifier.feed(chunk) for chunk in chunks) + deidentifier.flush()
+        assert output, f"{label} produced no output"
+
+
 @pytest.mark.asyncio
 async def test_success_hashes_exact_output_and_commits_before_done() -> None:
     release_commit = asyncio.Event()


### PR DESCRIPTION
## Change summary

Four mechanism-level defects found by measuring and probing the evidence, streaming and native-WAL paths, plus the regression coverage and proofs that were missing for all of them. Every one was found by exercising the code, not by reading it.

### 1. Commit cost grew with the length of the audit chain

`commit_forensic` and `commit_forensic_summary` append an MMR leaf before they know whether signing and WAL persistence will succeed, and revert the MMR if either fails. The revert was `copy.deepcopy(self._mmr)` — a copy of the whole accumulator, taken on *every* commit, including the successful ones. A `cProfile` of 300 commits attributed 2.775 s of 3.046 s (about 91%) to `deepcopy`, at 1,398,910 calls. Neither `fsync` (0.119 s in `_persist_node`) nor signing (0.065 s) was the bottleneck.

Replaced with `MerkleMountainRange.checkpoint()` / `rollback_to()`: a token holding the append-only lengths plus the live peak nodes. An append only extends `nodes` and `_leaf_node_indices`, and only sets `parent` on nodes as they are popped from `peaks`, so a node in `peaks` always has `parent is None` — truncating the two lists and reinstating the recorded peaks with cleared parents restores the prior state exactly. Both operations are O(log n).

**Trust boundary:** unchanged. A signing or WAL-persistence failure still leaves the MMR exactly as it was, so a failed commit still contributes no leaf and no WAL record. `rollback_to` raises rather than truncating when handed a checkpoint that is not a prefix of the current state.

### 2. Streaming redaction aborted ordinary text

`StreamingDeidentifier._reject_overlong_open_candidate` fails closed when a sensitive candidate cannot settle inside the bounded holdback. Two of its tests did not describe the grammar they guard:

- Track data was rejected whenever a `;` was followed by more than `window_chars` with no `?` anywhere. Prose after a semicolon never contains a `?`, so `"We shipped it; ..."` aborted the stream.
- The email candidate was measured from the last whitespace *before the cutoff* to the end of the buffer, spanning whole settled words. Any `@` in the holdback sufficed — a mentioned address, or a Python decorator.

Both now test whether the candidate is a viable prefix of the detector that would redact it. `_TRACK1_OPEN_PREFIX` / `_TRACK2_OPEN_PREFIX` are derived from `_TRACK1` / `_TRACK2` in `pci_detector`, and the email candidate is the trailing whitespace-free token, because the `EMAIL` pattern admits no whitespace.

This mattered because `aegis/proxy/streaming.py` maps `StreamingDeidentificationError` to a `privacy_failure` terminal outcome, so a false positive ends the client's stream on text containing nothing sensitive.

### 3. Fail-open in the same guard

Marker searches used the lowercase form while the URL and track-1 detectors are case-insensitive, so an unterminated `HTTPS://` or `%b` candidate passed the guard entirely — a fail-open on the exact grammar the guard exists to catch. Now searched case-insensitively.

### 4. `RustWal.open` truncated an existing segment

`OpenOptions::truncate(false)` stops `open` from clearing the file, and the comment above it says a WAL must never truncate an existing segment — but the `set_len(capacity)` that follows shrinks the file just the same. Reopening a populated segment with a smaller `capacity_bytes` discarded every frame past the new length: a 1 MiB segment holding 20 records, reopened at 64 bytes, retained 4. Reproduced, then fixed and re-verified against the rebuilt wheel (20 of 20 retained).

`app.py` always passes 256 MiB so this is not reachable from the gateway today, but `RustWal.open` and `aegis.core.rust_integration.new_rust_wal` both take an arbitrary capacity. The requested capacity is now a floor, so a segment only ever grows.

### Also: the WAL frame-bounds arithmetic is now proven

`header_range` and `payload_range` centralise the arithmetic that decided, in three places with three slightly different open-coded forms, whether a slice was in bounds. `read_all`, `scan_write_pos` and the walk in `open` all go through them. Five `#[kani::proof]` harnesses check over the whole `usize` domain that a returned range is inside the limit, that the arithmetic never overflows into an apparently valid range, that a zero-length payload (the recovery terminator) is never taken for a frame, that a walk strictly advances so it must terminate on arbitrary mapped bytes, and that header and payload ranges never overlap.

These differ in kind from the repository's other formal artifacts — they run against the real functions, not a separately written abstraction, so the refinement gap does not apply to them. `docs/formal/FORMAL_VERIFICATION_LIMITS.md` records exactly how narrow that exemption is: Kani models no mmap, no flush, no filesystem and no concurrency, so nothing here establishes durability, crash consistency, or that `capacity` equals the mapped length. Two new "do not say" rows were added there ("the WAL is memory-safe", "proven crash-safe").

### Known remaining over-trigger, deliberately not changed

The `ADDRESS` guard mirrors `_SAFE_HARBOR_PATTERNS`, whose address pattern allows an unbounded `[A-Za-z0-9 ]+` before the street-type suffix. A number-led run of letters, digits and spaces longer than the window is therefore a genuinely viable address prefix and still aborts (`"3 reasons the migration succeeded were better planning ..."`, 165 chars). Fixing it means bounding that quantifier in `phi_deidentifier.py`, which changes redaction behaviour outside the streaming path and trades availability against PHI recall. That is a decision for the owner, not a unilateral change.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Security fix (fail-open in the open-candidate guard; evidence-destroying WAL truncation)
- [ ] Documentation update
- [x] Refactor / code quality

## Evidence contract

- [x] I updated `docs/CLAIMS_MATRIX.md` for every new or changed public claim. — No public claim changed. No new claim is asserted: the performance work is recorded as bounded evidence, not as a capacity claim, and the Kani result is scoped in `docs/formal/FORMAL_VERIFICATION_LIMITS.md` rather than asserted as a new claim. `verify_claims.py` passes at 53 claims.
- [x] I identified the exact artifact, test, log, or benchmark supporting the claim. — `evidence/commit_scaling_measurement_2026-09-03.md` (+ `.sha256`), produced by the new `benchmarks/bench_commit_scaling.py`, indexed in `evidence/INDEX.md`, method row added to `docs/benchmarks/BENCHMARK_METHOD.md`. The Kani result is reproduced by `cargo kani` in `aegis_rust_v2/`.
- [x] I stated what the evidence does **not** establish. — For the measurement: in-process commit path only; excludes network, provider, request parsing, admission control, WAF, rate limiting and response handling; excludes durable-write cost by default; one container, one CPU model, one Python build, one date; establishes the *shape* of the cost curve, not throughput capacity, a service level, multi-replica behaviour, network-storage behaviour, or sustained load. For the proofs: two functions, no mmap, no durability, no concurrency. No production-scale measurement exists.
- [x] I did not include credentials, customer payloads, private endpoints, or synthetic telemetry presented as runtime evidence.

### Measurement

200 measured commits at each chain length, best of 2 trials, no-op `fsync` seam, same harness both sides:

| Prior leaves | Before (µs/commit) | After (µs/commit) | Ratio |
|---|---|---|---|
| 0 | 1,708.2 | 378.7 | 4.5× |
| 500 | 7,827.1 | 328.9 | 23.8× |
| 1,000 | 14,618.7 | 394.7 | 37.0× |
| 2,000 | 30,153.9 | 361.7 | 83.4× |

Normalised to each run's own shortest chain, the before curve rises `1.00× → 4.58× → 8.56× → 17.65×`; the after curve is `1.00× → 0.87× → 1.04× → 0.95×`. A wider run on the changed code (0–8,000 prior leaves, 300 commits, best of 3) gives `1.00× → 1.09× → 1.05× → 1.00× → 1.07× → 1.12×`; the residual rise at 8,000 tracks the growing WAL file, not the accumulator.

These are microbenchmark figures in one ephemeral container on 2026-09-03. They are not a capacity claim.

## Verification

- [x] `pytest` passes for the affected scope. — 5,876 passed, 39 skipped, 2 deselected, run against the rebuilt Rust wheel. The `slow`-marked 100,000-node sweep passes separately in 51 s.
- [x] `ruff check .` passes. — All checks passed.
- [x] `ruff format --check .` passes. — 460 files already formatted.
- [x] `bandit -r aegis aegis_server -lll` passes. — exit 0; 0 high-severity findings.
- [ ] `pip-audit` and relevant lockfile checks pass. — **`pip-audit` is not installed in this environment; not run.** No Python dependency or lockfile was touched. `Cargo.toml` gained only a `[lints.rust]` block; no dependency changed, and `cargo clippy --locked` succeeded, so `Cargo.lock` is unchanged.
- [x] If `sdk/python/**` changed: not applicable — unchanged.
- [x] If `sdk/typescript/**` changed: not applicable — unchanged.
- [x] If `dashboard/**` changed: not applicable — unchanged.
- [x] Rust, Helm, container, or benchmark gates were run when affected. — `cargo fmt --check` clean; `cargo clippy --locked --all-targets --all-features -- -D warnings` clean; `cargo test --lib` 31 passed; `cargo kani` 5 harnesses verified, 0 failures; `maturin build --release --features extension-module` succeeded and the resulting wheel was installed before the Python suite was re-run. Helm and container manifests unchanged.
- [x] Raw artifacts are attached or linked for performance measurements. — `evidence/commit_scaling_measurement_2026-09-03.md`, reproducible with `python -m benchmarks.bench_commit_scaling --json`.

`mypy` reports 20 errors on `aegis/core/mmr.py` and `aegis/core/crypto_audit.py`, which is exactly the count on the parent commit — this change introduces none. `mypy` is clean on `aegis/core/streaming_deidentifier.py`.

Documentation gates: `tools/docs/verify_documentation.py --root . --strict` PASS (0 errors, 0 warnings, 27 required files); `scripts/verify_docs.py` PASS; `scripts/verify_claims.py` PASS (53 claims); `scripts/verify_links.sh` PASS (1,016 links and anchors); `git diff --check` clean. `.aegis_ai_context/MANIFEST.json` regenerated for the edited governed inputs.

## Security and operations

- [x] Threat model and residual risk are updated. — The streaming change narrows one fail-open and removes three false-positive aborts; the residual `ADDRESS` over-trigger is documented above rather than silently narrowed. The WAL change removes an evidence-destroying path. `docs/formal/FORMAL_VERIFICATION_LIMITS.md` is updated with the new artifact, its exemption, and its limits.
- [x] Failure behavior is fail-closed where the evidence boundary requires it. — Pinned by test, not by inspection: `tests/test_mmr_rollback.py` asserts that a ledger whose commit failed at signing or at WAL persistence produces the same MMR, node for node, as a ledger that never attempted it, and that no WAL record is written; `tests/test_proxy_streaming.py` asserts unterminated URL, uppercase URL, track-1, lowercase track-1, track-2 and email candidates all still raise; `wal.rs` tests assert a reopen at a smaller capacity preserves every frame.
- [x] Rollback, blast radius, observability, and kill criteria are documented. — Blast radius is two internal call sites in `crypto_audit`, one private method in `streaming_deidentifier`, and `open`/`read_all`/`scan_write_pos` in `wal.rs`. No wire format, WAL record layout, proof schema, configuration key or public API changes, so rollback is a plain revert with no migration. The WAL fix only ever grows a segment, so reverting it cannot orphan data written under it. Kill criteria: any divergence in `tests/test_mmr_rollback.py`, `tests/test_mmr_parity.py`, or a `cargo kani` counterexample.
- [x] New secrets and sensitive data are absent from the diff.

## Release impact

- [x] Version and changelog updates are included when behavior or public claims change. — `CHANGELOG.md` `[Unreleased]` updated under Added / Changed / Fixed. No version anchor moved; the `4.0.2` source release target is untouched.
- [x] Commercial and buyer-facing language does not imply certification, SLO, legal admissibility, or customer references without evidence.
- [x] Human reviewer/owner: `@JuanLunaIA`

## Test plan

New coverage. Every area touched here was previously unasserted — the MMR rollback path, the memory-window anchor, Rust/Python proof agreement, the streaming false positives, and WAL segment growth all had no tests.

```bash
# Correctness of the rollback, and the ledger-level revert
pytest tests/test_mmr_rollback.py -q                          # 41 passed

# Chain integrity across memory-window rollover
pytest tests/test_crypto_audit_rollover.py -q -m "not slow"   # 13 passed
pytest tests/test_crypto_audit_rollover.py -q -m slow         # 1 passed in 51s (100,000 nodes)

# Rust/Python MMR agreement, including proofs against the Rust root
pytest tests/test_mmr_parity.py -q                            # 20 passed

# Streaming guards, both directions
pytest tests/test_proxy_streaming.py -q                       # 26 passed

# Full suite and gates
pytest -q -m "not slow"                                       # 5,876 passed, 39 skipped
ruff check . && ruff format --check .
bandit -r aegis aegis_server -lll
python tools/docs/verify_documentation.py --root . --strict
python scripts/verify_docs.py && python scripts/verify_claims.py && bash scripts/verify_links.sh

# Rust
cd aegis_rust_v2
cargo fmt --check
cargo clippy --locked --all-targets --all-features -- -D warnings
cargo test --lib                                              # 31 passed
cargo kani                                                    # 5 harnesses verified, 0 failures
maturin build --release --features extension-module

# Measurement
python -m benchmarks.bench_commit_scaling --lengths 0,500,1000,2000 --batch 200 --k 2 --json
```

Every new test and proof was checked for non-vacuity by reverting the fix it covers:

- Removing the parent-clearing loop from `rollback_to` fails 16 tests; skipping the node truncation fails 20; restoring peaks as copies rather than the live objects fails 25.
- Deleting the window-anchor update fails 9 rollover tests; making `verify_integrity` trust index 0 instead of comparing it to the anchor fails the dropped-node and tampered-anchor tests.
- Running the new streaming tests against the previous implementation fails 6 of them.
- Reverting the growth-only guard (`max` → `min`) fails both new `wal.rs` reopen tests.
- Replacing one `checked_add` with `wrapping_add` in `payload_range` makes `cargo kani` report a counterexample rather than succeeding vacuously.

`tests/test_crypto_audit_rollover.py::test_node_dropped_at_the_window_boundary_is_detected` deletes the oldest in-window node and first asserts every survivor is still self-consistent, so only the `prev_hash == anchor` comparison can catch it — the per-node hash check cannot.

## Note on CI

The new `Kani Model Checking` job is deliberately absent from the `docker` job's `needs`. `cargo kani setup` downloads a third-party toolchain bundle, and a release should not become unshippable because that host is unavailable. The proofs run as a PR check instead; the rationale is in a comment on the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXm9uxZjTkDFnaV6U8R9oa

## Summary by Sourcery

Make audit commits chain-length-independent, preserve streaming availability and WAL evidence, and verify native WAL frame-boundary arithmetic with scoped formal proofs.

Bug Fixes:
- Prevent streaming deidentification from aborting ordinary prose while preserving fail-closed handling for genuine overlong URL, track-data, email, and case-insensitive candidates.
- Prevent reopening native WAL segments with a smaller capacity from truncating previously persisted records.

Enhancements:
- Replace full MMR snapshots with O(log n) checkpoints and rollback tokens so commit cost remains effectively constant as the audit chain grows.
- Centralize native WAL frame-bound arithmetic and add Kani proofs covering bounds, overflow, termination, recovery terminators, and range separation.

CI:
- Add a pinned Kani model-checking workflow job for native WAL frame-bounds proofs without making release jobs depend on the external toolchain download.

Documentation:
- Document commit-scaling measurement boundaries and the narrow scope and limitations of the new Kani verification artifacts.
- Record benchmark evidence and update the changelog for the MMR, streaming, WAL, and verification changes.

Tests:
- Add regression coverage for exact MMR rollback and failed-commit evidence preservation.
- Add tests for audit-chain integrity across memory-window rollover and Python/Rust MMR proof parity.
- Add streaming guard regressions and WAL reopen/growth coverage.