### PR TITLE
fix(ci): stop the SBOM job attaching an unmanifested asset to the release

### DIFF
--- a/.aegis_ai_context/MANIFEST.json
+++ b/.aegis_ai_context/MANIFEST.json
@@ -321,8 +321,8 @@
     {
       "category": "governed_input",
       "path": ".github/workflows/ci.yml",
-      "sha256": "f1d2ea3f7a5aa0a1926aa5aabfe3935a43544c03f7061ce5044c4e23e5495918",
-      "size": 27196
+      "sha256": "37aaab23b749fb2a7993c6e0b7c13b2f9cb379062d0e1a0e3ce9e17246f054c8",
+      "size": 28307
     },
     {
       "category": "governed_input",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,10 +539,9 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [test, security, market-hardening]
     permissions:
-      contents: write
+      contents: read
       id-token: write
       attestations: write
-      actions: read
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Build source artifact
@@ -556,6 +555,24 @@ jobs:
           path: sbom-root
           format: spdx-json
           output-file: sbom.spdx.json
+          # `anchore/sbom-action` defaults this to true, so on a
+          # `release: published` event it tried to attach an SBOM to the
+          # release and failed with "Resource not accessible by integration"
+          # against this job's `contents: read`.
+          #
+          # Raising the scope to `contents: write` would silence the error but
+          # publish an asset that `release.yml` did not produce: not listed in
+          # `release-asset-manifest.json` and not hashed in `SHA256SUMS`. The
+          # documented way to verify a release asset is to download the bytes
+          # and check them against `SHA256SUMS`, so an unmanifested asset is a
+          # hole in that instruction, not a convenience.
+          #
+          # `release.yml` is the single owner of release assets, and it emits
+          # its own canonical `aegis-latent-core-<version>.spdx.json` with a
+          # sidecar. This job's product is the workflow artifact plus the
+          # attestation below, which is why the upload is off and the token
+          # stays read-only.
+          upload-release-assets: false
       - name: Attest source SBOM
         if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         uses: actions/attest-sbom@bd218ad0dbcb3e146bd073d1d9c6d78e08aa8a0b # v2


### PR DESCRIPTION
## The CI failure

`Generate SBOM` failed on the `v4.1.0` release event:

```
##[error]Resource not accessible by integration - https://docs.github.com/rest
```

The step before it says what it was doing: `--------------------- Attaching SBOMs to release: 'v4.1.0' ---------------------`.

**Cause.** `anchore/sbom-action` defaults `upload-release-assets` to **true**, and `ci.yml` never set the input. The runner log echoes the resolved value:

```
with:
  path: sbom-root
  format: spdx-json
  output-file: sbom.spdx.json
  upload-release-assets: true      ← never set in ci.yml; the action's default
```

Against this job's token — `Contents: read` in the same log — attaching a release asset is not permitted. It only surfaces on a `release: published` event, which is why main and every pull request stayed green.

## Why not just grant `contents: write`

That clears the error, but it publishes a release asset `release.yml` did not produce:

| | `release.yml` SBOM | the `ci.yml` upload |
|---|---|---|
| Filename | `aegis-latent-core-<version>.spdx.json` | `aegis-latent-core-sbom.spdx.json` |
| In `release-asset-manifest.json` | yes | **no** |
| Hashed in `SHA256SUMS` | yes | **no** |
| `.sha256` sidecar | yes | **no** |

`docs/RELEASE_STATUS.md` tells a consumer to download the bytes and check them against `SHA256SUMS`. An asset outside that manifest is a hole in the instruction, not a convenience — and on an evidence-gateway project that is the wrong trade for silencing a permissions error.

## The fix

`release.yml` is the single owner of release assets. This job's products are the workflow artifact and the SBOM attestation, neither of which needs write access:

- `upload-release-assets: false`, set explicitly with the reasoning in a comment so the default cannot creep back.
- `contents: write` → `contents: read`.
- `actions: read` removed — it was only reachable through the release-asset path.

```yaml
permissions:
  contents: read
  id-token: write
  attestations: write
```

## What this does NOT fix

**The `v4.1.0` release is empty because no workflow in this repository is tag-triggered.** Verified across all ten:

| Workflow | Triggers |
|---|---|
| `release.yml` | `workflow_dispatch` only |
| `create_release_tag.yml` | `workflow_dispatch` only |
| `publish_pypi.yml` / `publish_npm.yml` / `publish_oci.yml` | `workflow_dispatch` only |
| `ci.yml` | `push` (branches), `pull_request`, `release`, `workflow_dispatch` |
| `forensic.yml` / `security.yml` | `push` (branches), `pull_request`, `schedule`, `workflow_dispatch` |

Pushing a tag by hand therefore runs **nothing**. The asset set `v4.0.2` carried — core wheel and sdist, both SDKs, seven Rust platform wheels, two SPDX SBOMs, `release-asset-manifest.json`, `SHA256SUMS` and a `.sha256` per artifact — is built by `release.yml`, which was never dispatched. The missing **Deployments** have the same cause: they come from the `environment: release` blocks in `create_release_tag.yml` and `release.yml`, and neither ran.

**The current tag also cannot be used by the pipeline.** `scripts/verify_release_tag.sh` asserts:

```bash
test "$(git cat-file -t "refs/tags/${release_tag}")" = tag
gitsign verify-tag --certificate-identity \
  ".../create_release_tag.yml@refs/heads/main" ...
```

Measured on the current tags:

```
git cat-file -t v4.0.2  →  tag      (signed annotated)
git cat-file -t v4.1.0  →  commit   (lightweight)
```

A hand-made tag is lightweight and carries no Sigstore signature from the workflow's OIDC identity, so it fails both assertions. Recovery requires deleting the tag and the hand-made release, then dispatching `create_release_tag.yml` (which signs and pushes the annotated tag) followed by `release.yml`. `scripts/create_github_release.py` is create-only, so a pre-existing release for the same tag makes that step fail — the release has to go first.

Those are publication actions against `main`, so they are not performed here.

## Verification

| Gate | Result |
|---|---|
| `ci.yml` parses; `sbom` permissions resolve to `contents: read`, `id-token: write`, `attestations: write` | confirmed |
| `sbom-action` inputs resolve with `upload-release-assets: False` | confirmed |
| `scripts/verify_github_action_pins.py` | PASS (117 remote references) |
| `scripts/verify_docs.py` | PASS |
| `scripts/verify_claims.py` | PASS (59 claims) |
| `tools/docs/verify_documentation.py --root . --strict` | PASS |
| `scripts/verify_release_contract.py --root .` | READY |
| `git diff --check` | clean |

`ci.yml` is a governed input in the AI-context manifest, so `.aegis_ai_context/MANIFEST.json` is regenerated in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXm9uxZjTkDFnaV6U8R9oa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXm9uxZjTkDFnaV6U8R9oa)_

## Summary by Sourcery

Keep SBOM generation read-only and prevent CI from publishing release assets outside the canonical release manifest.

Bug Fixes:
- Prevent the SBOM job from attempting to attach an unmanifested release asset on published release events.

Enhancements:
- Restrict the SBOM job to read-only repository contents access while retaining permissions required for attestations.
- Make release asset ownership explicit by keeping canonical release assets under the release workflow and disabling SBOM release uploads.

CI:
- Update the CI workflow permissions and SBOM configuration to avoid release-upload failures caused by the action default.
- Regenerate the AI-context manifest for the governed CI workflow input.