### PR TITLE
fix(release): npm publish read its tarball path as a GitHub repo shorthand

### DIFF
--- a/.aegis_ai_context/MANIFEST.json
+++ b/.aegis_ai_context/MANIFEST.json
@@ -105,8 +105,8 @@
     {
       "category": "governed_input",
       "path": "CHANGELOG.md",
-      "sha256": "5b4c33864d1aaee552d94ec4261566dc1f1fa83b487c78b955eefa0a0e666ad2",
-      "size": 54002
+      "sha256": "4dac410176479b9ea672436f8158fcb8dbc58eeb6c9354e815a49864a6e319b1",
+      "size": 55102
     },
     {
       "category": "governed_input",
@@ -351,8 +351,8 @@
     {
       "category": "governed_input",
       "path": ".github/workflows/publish_npm.yml",
-      "sha256": "8c9edee74535d409613f49f1c942b8e3040fa6e033bf1e24d9b060be41926f36",
-      "size": 4498
+      "sha256": "1f31549c0415ffa1c95815e20c20a3f75de774d7230e0a91ee19372edff34016",
+      "size": 5511
     },
     {
       "category": "governed_input",
@@ -465,8 +465,8 @@
     {
       "category": "governed_input",
       "path": "scripts/verify_release_contract.py",
-      "sha256": "e36bfbe8e4ad65720f54211f8888f95feb86bb0680667db63a7d2efba94650d4",
-      "size": 41087
+      "sha256": "a01add9db8e5b1589ebb8a1ddf55679772486b12bb313e764748f5bf56f706ef",
+      "size": 42406
     },
     {
       "category": "governed_input",

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -118,4 +118,23 @@ jobs:
           name: typescript-sdk-package-${{ inputs.expected_target }}
           path: release-artifact
       - name: Publish to npm with OIDC provenance
-        run: npm publish release-artifact/*.tgz --access public --provenance
+        # `npm publish` parses its argument as a package spec, not as a path.
+        # A bare `a/b` is npm's GitHub shorthand for `owner/repo`, so
+        # `npm publish release-artifact/*.tgz` made npm try to clone
+        # `ssh://git@github.com/release-artifact/aegis-latent-sdk-<v>.tgz.git`
+        # and fail with "Permission denied (publickey)" — the v4.1.1 dispatch
+        # died there while PyPI published. The leading `./` is what makes npm
+        # read it as a filesystem path.
+        #
+        # The count check is not incidental: the glob previously fed whatever
+        # it matched straight to npm, so a second tarball in the directory
+        # would silently decide which artifact got published.
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          tarballs=(./release-artifact/*.tgz)
+          if [ "${#tarballs[@]}" -ne 1 ]; then
+            echo "::error::expected exactly one downloaded tarball, found ${#tarballs[@]}: ${tarballs[*]}"
+            exit 1
+          fi
+          npm publish "${tarballs[0]}" --access public --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No source changes since `4.1.1`.
+### Fixed
+
+- `publish_npm.yml` ran `npm publish release-artifact/*.tgz`. `npm publish`
+  parses its argument as a package spec, and a bare `a/b` path is npm's GitHub
+  `owner/repo` shorthand, so npm attempted
+  `git ls-remote ssh://git@github.com/release-artifact/aegis-latent-sdk-4.1.1.tgz.git`
+  and exited 128 with `Permission denied (publickey)`. The `4.1.1` dispatch died
+  there while PyPI published from the same run. The step now passes a
+  `./`-prefixed path and fails loudly if the download directory holds anything
+  other than exactly one tarball, which the glob previously left to chance.
+- The same unpublishable command was pinned in two more places: the assertion in
+  `tests/test_release_contract_v4.py` and the `npm.provenance` regex in
+  `scripts/verify_release_contract.py` both required that literal, so the
+  release contract validated a command that could not work. The contract now
+  checks the properties the release needs — provenance, public access, and a
+  path npm resolves as a file — against the workflow with comment lines removed,
+  since a comment explaining a forbidden form has to contain it.
 
 ## [4.1.1] — 2026-09-03
 

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -16,16 +16,38 @@
 
 Nothing in this table may be restated with the version number changed. A `4.0.2` digest is not a `4.1.1` digest, and a `4.0.2` signature attests to `4.0.2` bytes.
 
-### 1.1 The current source baseline
+### 1.1 `4.1.1` — published, read back 2026-09-03
 
-| Surface | State | Observed value | Readback |
-| --- | --- | --- | --- |
-| Source baseline | Confirmed | `4.1.1`, fourteen synchronized anchors, contract `READY` | §2.1 |
-| GitHub tag `v4.1.1` | **Not created** | No tag exists | — |
-| GitHub Release `v4.1.1` | **Not published** | No release exists | — |
-| PyPI / npm at `4.1.1` | **Not published** | No package exists | — |
-| OCI image at `4.1.1` | **Not published** | No image exists | — |
-| Signatures / attestations for `4.1.1` | **Do not exist** | Nothing has been signed or attested | — |
+| Surface | State | Observed value |
+| --- | --- | --- |
+| Source baseline | Confirmed | `4.1.1`, fourteen synchronized anchors, contract `READY` |
+| GitHub tag `v4.1.1` | Confirmed, signed annotated | `git cat-file -t v4.1.1` → `tag`; targets `5a137c86ecd914842493babb7e863033498f68c9`; tagger identity `.../create_release_tag.yml@refs/heads/main`; Sigstore certificate issued 2026-09-03T17:30:54Z |
+| GitHub Release `v4.1.1` | Confirmed | Published 2026-09-03T17:37:02Z, non-draft, non-prerelease, **31 assets**, `immutable: true` |
+| Release asset integrity | **Confirmed by byte check** | `sha256sum --check --strict SHA256SUMS` → OK for all fifteen artifacts |
+| PyPI (`aegis-latent-sdk`) | **Confirmed published at 4.1.1** | `pip index versions` → available: `4.1.1`, `4.0.0` |
+| npm (`aegis-latent-sdk`) | **Not published at 4.1.1** | `npm view aegis-latent-sdk version` → `4.0.0`. The publish job failed; see below |
+| OCI images at `4.1.1` | Not read back | `crane`/`cosign` were not run for this version |
+| Build attestations | Emitted by the workflow; not independently verified | Verify per artifact with `gh attestation verify` |
+
+**The npm publish failed for a fixable reason, not a policy one.** `publish_npm.yml`
+ran `npm publish release-artifact/*.tgz`. `npm publish` parses its argument as a
+package spec, and a bare `a/b` path is npm's GitHub `owner/repo` shorthand, so
+npm attempted
+`git ls-remote ssh://git@github.com/release-artifact/aegis-latent-sdk-4.1.1.tgz.git`
+and exited 128 with `Permission denied (publickey)`. The step now passes a
+`./`-prefixed path. `AEGIS_TRUSTED_PUBLISHING_ENABLED` was set correctly — PyPI
+published from the same dispatch, which is what rules the variable out as the
+cause.
+
+**Republishing npm does not need a new version.** Nothing was uploaded to the
+registry for `4.1.1`, so the corrected `publish_npm.yml` can be dispatched
+against the existing signed tag.
+
+**`git verify-tag v4.1.1` reports a missing issuer certificate.** That is the
+expected result for a Sigstore short-lived certificate under `gpgsm`, which has
+no Sigstore root, and is the same condition §3 describes for the GitHub badge.
+Trust requires `gitsign verify-tag` against the transparency log with an explicit
+certificate identity, not `git verify-tag`.
 
 ### 1.2 `4.1.0` — tagged and released outside the pipeline, observed 2026-09-03
 

--- a/scripts/verify_release_contract.py
+++ b/scripts/verify_release_contract.py
@@ -431,10 +431,21 @@ def _validate_npm_workflow(root: Path, diagnostics: list[Diagnostic]) -> None:
         "npm.environment": "name: npm" in workflow,
         "npm.oidc": "id-token: write" in workflow
         and "registry-url: https://registry.npmjs.org" in workflow,
-        "npm.provenance": re.search(
-            r"npm publish\s+release-artifact/\*\.tgz[^\n]*--provenance", workflow
-        )
-        is not None,
+        # This required the literal `npm publish release-artifact/*.tgz`, which
+        # pinned a command that cannot work: `npm publish` reads its argument as
+        # a package spec, and a bare `a/b` is npm's GitHub `owner/repo`
+        # shorthand, so npm tried to clone a repository instead of reading the
+        # tarball. The v4.1.1 dispatch failed there while PyPI published. The
+        # check now asserts the properties the release needs — provenance,
+        # public access, and a path npm resolves as a file — rather than one
+        # spelling of the command.
+        "npm.provenance": "--provenance" in workflow and "--access public" in workflow,
+        # Matched against the workflow with comment lines removed: the comment
+        # above the publish step has to name the broken form in order to
+        # explain it, exactly as the documentation gates must name a phrase to
+        # prohibit it.
+        "npm.publish-path": "./release-artifact/*.tgz" in workflow
+        and re.search(r"npm publish\s+release-artifact/", _without_yaml_comments(workflow)) is None,
         "npm.main-ancestry": 'scripts/verify_release_tag.sh "${RELEASE_TAG}" "${EXPECTED_TAG_TARGET}"'
         in workflow,
         "npm.signed-tag": 'scripts/verify_release_tag.sh "${RELEASE_TAG}" "${EXPECTED_TAG_TARGET}"'
@@ -816,6 +827,15 @@ def _validate_package_identity(root: Path, diagnostics: list[Diagnostic]) -> Non
         "forensic report default version must derive from aegis.__version__",
         "aegis/core/forensic_pdf_report.py",
     )
+
+
+def _without_yaml_comments(text: str) -> str:
+    """Drop whole-line YAML comments so a check cannot match its own rationale.
+
+    A comment that explains why a form is forbidden necessarily contains that
+    form. Without this, documenting the reason would trip the check.
+    """
+    return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
 
 
 def _validate_active_deployment_versions(

--- a/tests/test_release_contract_v4.py
+++ b/tests/test_release_contract_v4.py
@@ -229,7 +229,19 @@ def test_publish_workflows_are_verified_dispatch_only_and_publish_downloaded_art
         assert "ref: ${{ env.EXPECTED_TAG_TARGET }}" in workflow
         assert "AEGIS_TRUSTED_PUBLISHING_ENABLED" in workflow
     assert "packages-dir: release-artifact" in pypi
-    assert "npm publish release-artifact/*.tgz --access public --provenance" in npm
+
+    # This previously asserted `npm publish release-artifact/*.tgz`, which
+    # pinned the defect as the contract. `npm publish` reads its argument as a
+    # package spec, and a bare `a/b` is npm's GitHub `owner/repo` shorthand, so
+    # that form made npm try to clone
+    # `ssh://git@github.com/release-artifact/aegis-latent-sdk-<v>.tgz.git`. The
+    # v4.1.1 dispatch died there with "Permission denied (publickey)" while
+    # PyPI published normally. A leading `./` makes npm read a filesystem path.
+    npm_without_comments = "\n".join(
+        line for line in npm.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "npm publish release-artifact/" not in npm_without_comments
+    assert "./release-artifact/*.tgz" in npm
 
 
 def test_oci_workflow_publishes_multiarch_by_digest_with_keyless_signature() -> None:


### PR DESCRIPTION
The `v4.1.1` release succeeded except for npm. This fixes the cause and the two places that hid it.

## What the dispatch actually produced

| Surface | Result |
|---|---|
| Tag `v4.1.1` | **Signed annotated** — `git cat-file -t` → `tag`, Sigstore cert, identity `create_release_tag.yml@refs/heads/main`, targets `5a137c8` |
| GitHub Release | **31 assets**, non-draft, non-prerelease |
| Asset integrity | `sha256sum --check --strict SHA256SUMS` → **OK on all 15 artifacts** |
| PyPI | **`aegis-latent-sdk 4.1.1` published** |
| npm | **Failed** — still `4.0.0` |

## The npm failure

```
npm error code 128
npm error command git --no-replace-objects ls-remote \
  ssh://git@github.com/release-artifact/aegis-latent-sdk-4.1.1.tgz.git
npm error git@github.com: Permission denied (publickey).
```

`npm publish` parses its argument as a **package spec, not a path**. A bare `a/b` is npm's GitHub `owner/repo` shorthand, so `npm publish release-artifact/*.tgz` made npm try to clone a repository named after the tarball. A leading `./` is what makes npm resolve a filesystem path.

**PyPI publishing from the same dispatch is what rules out the obvious alternative explanation** — `AEGIS_TRUSTED_PUBLISHING_ENABLED` was set correctly, and this was never a gating problem.

The step now also fails if the download directory holds anything other than exactly one tarball. The glob fed npm whatever it matched, so a second tarball would have silently decided which artifact got published. Verified against all three cases (one, two, zero tarballs).

## Why no gate caught it

The same unpublishable command was pinned in two more places:

- `tests/test_release_contract_v4.py` asserted the literal `npm publish release-artifact/*.tgz --access public --provenance`.
- `scripts/verify_release_contract.py` required it by regex under `npm.provenance`.

**Both encoded the defect as the contract.** The release contract was validating a command that could not work, and reported `READY` right up to the dispatch.

The check now asserts the properties the release needs — provenance, public access, and a path npm resolves as a file — rather than one spelling of the command:

```python
"npm.provenance": "--provenance" in workflow and "--access public" in workflow,
"npm.publish-path": "./release-artifact/*.tgz" in workflow
and re.search(r"npm publish\s+release-artifact/", _without_yaml_comments(workflow)) is None,
```

Both the check and the test match against the workflow with comment lines stripped. The comment explaining the broken form necessarily contains it — the same problem the documentation gates already solve when a rule has to name the phrase it prohibits.

## Release status recorded as observed

`docs/RELEASE_STATUS.md` §1.1 now carries the `4.1.1` readback as measured, not as intent: the tag properties, the 31 assets, the byte-level `SHA256SUMS` result, PyPI at `4.1.1`, npm at `4.0.0` with the reason and the fact that nothing reached the registry — so **the corrected workflow can be dispatched against the existing signed tag without a new version**.

It also records that `git verify-tag` reporting a missing issuer certificate is the expected `gpgsm` result for a Sigstore short-lived certificate, not a verification failure. That is the same condition §3 already describes for the GitHub badge; real verification needs `gitsign verify-tag` against the transparency log.

## Verification

| Gate | Result |
|---|---|
| `pytest -q -m "not slow"` | 5,974 passed, 52 skipped |
| `mypy --strict aegis` | 0 issues, 177 files |
| `ruff check .` / `ruff format --check .` | clean, 465 files |
| `verify_release_contract.py --root . --tag v4.1.1` | **READY** |
| `verify_github_action_pins.py` | PASS (117) |
| `verify_docs` / `verify_claims` (59) / `verify_links` (1024) | PASS |
| `verify_documentation.py --strict` | PASS |
| `publish_npm.yml` parses as YAML | confirmed |
| Tarball-count guard, three cases | one → publishes; two → fails; zero → fails |
| `git diff --check` | clean |

## After merging

npm only. No new tag, no new version:

```bash
gh workflow run publish_npm.yml --repo JuanLunaIA/aegis-latent-core --ref main \
  -f release_tag=v4.1.1 -f expected_target=5a137c86ecd914842493babb7e863033498f68c9

npm view aegis-latent-sdk version   # expect 4.1.1
```

Worth also reading back the OCI images, which were not checked for this version:

```bash
crane digest ghcr.io/juanlunaia/aegis-latent-core:4.1.1
```

Send me both results and I will finish §1.1 with the npm and OCI rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXm9uxZjTkDFnaV6U8R9oa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXm9uxZjTkDFnaV6U8R9oa)_

## Summary by Sourcery

Correct npm artifact publishing and strengthen release validation so the existing v4.1.1 tag can be republished successfully.

Bug Fixes:
- Fix npm publishing by passing the downloaded tarball as a filesystem path instead of an ambiguous GitHub repository shorthand.
- Fail npm publishing when the artifact directory does not contain exactly one tarball.

Enhancements:
- Update release-contract validation and tests to verify npm publishing requirements without encoding the broken command form.
- Record the observed v4.1.1 release status, including the npm failure and successful tag, release, asset, and PyPI readbacks.

Documentation:
- Document the v4.1.1 release results and explain the npm failure and Sigstore tag-verification behavior.

Tests:
- Update release contract tests to validate the corrected npm publish path and ignore explanatory workflow comments.

Chores:
- Refresh governed-input manifest hashes and sizes for the changed release files.