### PR TITLE
Clear the sixteen CodeQL notes raised on the merged #153

### DIFF
--- a/aegis/core/stream_redactor.py
+++ b/aegis/core/stream_redactor.py
@@ -83,17 +83,22 @@ class StreamRedactor(Protocol):
     """
 
     @property
-    def retained_chars(self) -> int: ...
+    def retained_chars(self) -> int:
+        """Characters currently withheld, summed across every stage."""
 
     @property
-    def window_chars(self) -> int: ...
+    def window_chars(self) -> int:
+        """The effective ``W`` for the per-stream retained-byte ceiling."""
 
     @property
-    def stats(self) -> StreamRedactionStats: ...
+    def stats(self) -> StreamRedactionStats:
+        """Bounded, non-sensitive redaction counters."""
 
-    def feed(self, text: str) -> str: ...
+    def feed(self, text: str) -> str:
+        """Consume a chunk and return the text that has settled."""
 
-    def flush(self) -> str: ...
+    def flush(self) -> str:
+        """Release the holdback at normal stream termination."""
 
 
 class CompositeStreamRedactor:

--- a/tests/compat/test_public_api_compat.py
+++ b/tests/compat/test_public_api_compat.py
@@ -49,10 +49,10 @@ py/side-effect-in-assert).
 from __future__ import annotations
 
 import importlib
+import importlib.metadata
 import inspect
 import os
 import tempfile
-from importlib import metadata
 from typing import Any
 
 import pytest
@@ -193,7 +193,7 @@ class TestConsoleEntryPoints:
     def test_both_scripts_are_installed_and_unchanged(self) -> None:
         installed = {
             entry.name: entry.value
-            for entry in metadata.entry_points(group="console_scripts")
+            for entry in importlib.metadata.entry_points(group="console_scripts")
             if entry.name in V412_CONSOLE_SCRIPTS
         }
         assert installed == V412_CONSOLE_SCRIPTS

--- a/tests/licensing/test_license_model.py
+++ b/tests/licensing/test_license_model.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 import pytest
 
-import aegis.licensing.model
+from aegis.licensing import model as license_model
 from aegis.licensing.model import KNOWN_MODULES, WILDCARD_MODULE, LicenseEntitlement
 
 EXPIRY = 1_800_000_000
@@ -155,7 +155,7 @@ class TestShape:
         and the package re-exports the verifier, which does import it.
         """
 
-        source = Path(aegis.licensing.model.__file__ or "").read_text(encoding="utf-8")
+        source = Path(license_model.__file__ or "").read_text(encoding="utf-8")
         imported: set[str] = set()
         for node in ast.walk(ast.parse(source)):
             if isinstance(node, ast.Import):

--- a/tests/test_mmr_v2_migration.py
+++ b/tests/test_mmr_v2_migration.py
@@ -141,11 +141,8 @@ class TestRustPythonParity:
 class TestLedgerSelection:
     def test_the_default_is_v1(self, tmp_path: Path) -> None:
         # Existing deployments must be unaffected by the option existing.
-        ledger = _ledger(tmp_path / "default.wal", HASH_SCHEME_V1)
-        try:
+        with _ledger(tmp_path / "default.wal", HASH_SCHEME_V1) as ledger:
             assert ledger.mmr_hash_scheme == HASH_SCHEME_V1
-        finally:
-            ledger.close()
 
     def test_the_config_default_is_v1(self) -> None:
         from aegis.config import AegisSettings
@@ -161,14 +158,11 @@ class TestLedgerSelection:
     def test_a_chain_commits_and_verifies_under_either_scheme(
         self, tmp_path: Path, scheme: str
     ) -> None:
-        ledger = _ledger(tmp_path / f"{scheme}.wal", scheme)
-        try:
+        with _ledger(tmp_path / f"{scheme}.wal", scheme) as ledger:
             _commit(ledger, 5)
             valid, index = ledger.verify_integrity()
             assert valid is True
             assert index is None
-        finally:
-            ledger.close()
 
     @pytest.mark.parametrize(
         ("scheme", "expected_version"),
@@ -181,26 +175,20 @@ class TestLedgerSelection:
         self, tmp_path: Path, scheme: str, expected_version: str
     ) -> None:
         # A verifier never has to guess which construction to check under.
-        ledger = _ledger(tmp_path / f"{scheme}-proof.wal", scheme)
-        try:
+        with _ledger(tmp_path / f"{scheme}-proof.wal", scheme) as ledger:
             _commit(ledger, 2)
             node = ledger.chain[-1]
             assert node.mmr_proof is not None
             assert node.mmr_proof["version"] == expected_version
-        finally:
-            ledger.close()
 
     def test_the_two_schemes_produce_different_roots_for_the_same_records(
         self, tmp_path: Path
     ) -> None:
         roots = []
         for scheme in (HASH_SCHEME_V1, HASH_SCHEME_V2):
-            ledger = _ledger(tmp_path / f"roots-{scheme}.wal", scheme)
-            try:
+            with _ledger(tmp_path / f"roots-{scheme}.wal", scheme) as ledger:
                 _commit(ledger, 4)
                 roots.append(ledger.chain[-1].merkle_root)
-            finally:
-                ledger.close()
         assert roots[0] != roots[1]
 
 
@@ -215,49 +203,34 @@ class TestNoInPlaceMigration:
         self, tmp_path: Path, written: str, reopened: str
     ) -> None:
         wal = tmp_path / "chain.wal"
-        first = _ledger(wal, written)
-        try:
+        with _ledger(wal, written) as first:
             _commit(first, 3)
-        finally:
-            first.close()
 
-        second = _ledger(wal, reopened)
-        try:
+        with _ledger(wal, reopened) as second:
             # Not "wal_corrupt" and not "mmr_replay_mismatch": both would be
             # true statements about the roots and wrong about the evidence,
             # which is intact.
             assert second._fault_state == "mmr_scheme_mismatch"
-        finally:
-            second.close()
 
     @pytest.mark.parametrize("scheme", [HASH_SCHEME_V1, HASH_SCHEME_V2])
     def test_reopening_under_the_same_scheme_replays_cleanly(
         self, tmp_path: Path, scheme: str
     ) -> None:
         wal = tmp_path / "reopen.wal"
-        first = _ledger(wal, scheme)
-        try:
+        with _ledger(wal, scheme) as first:
             _commit(first, 4)
             root_before = first.chain[-1].merkle_root
-        finally:
-            first.close()
 
-        second = _ledger(wal, scheme)
-        try:
+        with _ledger(wal, scheme) as second:
             assert second._fault_state == "healthy"
             assert second.chain[-1].merkle_root == root_before
             valid, index = second.verify_integrity()
             assert valid is True
             assert index is None
-        finally:
-            second.close()
 
     def test_an_empty_wal_accepts_either_scheme(self, tmp_path: Path) -> None:
         # Nothing has been recorded, so no root is being contradicted.
         wal = tmp_path / "empty.wal"
         wal.touch()
-        ledger = _ledger(wal, HASH_SCHEME_V2)
-        try:
+        with _ledger(wal, HASH_SCHEME_V2) as ledger:
             assert ledger._fault_state == "healthy"
-        finally:
-            ledger.close()

--- a/tests/test_streaming_safety_engine_integration.py
+++ b/tests/test_streaming_safety_engine_integration.py
@@ -52,6 +52,27 @@ def _event(text: str) -> tuple[bytes, Any]:
     return b"data: " + json.dumps(payload).encode(), payload
 
 
+def _content_of(part: bytes) -> list[str]:
+    """The assistant content carried by one yielded SSE part.
+
+    Skips the terminal ``data: [DONE]`` marker deliberately. The proxy yields
+    that marker on every successful stream whether or not any data event
+    survived, so counting it as output makes "something was emitted" true of a
+    proxy that emitted nothing.
+    """
+
+    found: list[str] = []
+    for line in part.split(b"\n"):
+        if not line.startswith(b"data: ") or line == b"data: [DONE]":
+            continue
+        body = json.loads(line[len(b"data: ") :])
+        for choice in body.get("choices", []):
+            content = choice.get("delta", {}).get("content")
+            if isinstance(content, str):
+                found.append(content)
+    return found
+
+
 async def _drain(chunks: list[str], **kwargs: Any) -> str:
     """Run chunks through a real proxy and return the concatenated content."""
 
@@ -78,14 +99,7 @@ async def _drain(chunks: list[str], **kwargs: Any) -> str:
     )
     seen: list[str] = []
     async for part in proxy:
-        for line in part.split(b"\n"):
-            if not line.startswith(b"data: ") or line == b"data: [DONE]":
-                continue
-            body = json.loads(line[len(b"data: ") :])
-            for choice in body.get("choices", []):
-                content = choice.get("delta", {}).get("content")
-                if isinstance(content, str):
-                    seen.append(content)
+        seen.extend(_content_of(part))
     return "".join(seen)
 
 
@@ -244,13 +258,19 @@ class TestRetentionAccounting:
         assert proxy.retained_bytes_ceiling == (
             UTF8_MAX_BYTES_PER_CHAR * (128 + FRONTIER) + 16_384 + 4096 + 4096
         )
-        emitted = 0
+        emitted: list[str] = []
         async for part in proxy:
-            emitted += len(part)
+            emitted.extend(_content_of(part))
             assert proxy.retained_bytes <= proxy.retained_bytes_ceiling
-        # Assert the stream actually ran: a proxy that yielded nothing would
-        # satisfy the ceiling check vacuously.
-        assert emitted > 0
+
+        # The ceiling assertion above holds vacuously against a proxy that
+        # emits nothing, and counting yielded *bytes* does not close that: the
+        # terminal `data: [DONE]` marker is 14 bytes and is yielded on every
+        # successful stream, so a proxy that dropped every data event would
+        # still clear a byte-count check. Assert on the redacted payload.
+        redacted = "".join(emitted)
+        assert "123-45-6789" not in redacted
+        assert redacted.count("[REDACTED:SSN]") == 500
 
 
 class TestEngineSelection:

--- a/tests/test_streaming_safety_engine_integration.py
+++ b/tests/test_streaming_safety_engine_integration.py
@@ -244,8 +244,13 @@ class TestRetentionAccounting:
         assert proxy.retained_bytes_ceiling == (
             UTF8_MAX_BYTES_PER_CHAR * (128 + FRONTIER) + 16_384 + 4096 + 4096
         )
-        async for _part in proxy:
+        emitted = 0
+        async for part in proxy:
+            emitted += len(part)
             assert proxy.retained_bytes <= proxy.retained_bytes_ceiling
+        # Assert the stream actually ran: a proxy that yielded nothing would
+        # satisfy the ceiling check vacuously.
+        assert emitted > 0
 
 
 class TestEngineSelection:


### PR DESCRIPTION
## Change summary

`#153` merged with sixteen note-severity CodeQL alerts open, so they are on `main` now. All sixteen are in code that PR introduced, and each is worth fixing rather than dismissing. No behaviour changes.

| Alert | Where | Fix |
|---|---|---|
| `Statement has no effect` ×5 | `aegis/core/stream_redactor.py` | `StreamRedactor` Protocol bodies were bare `...`; they now carry docstrings |
| `Should use a 'with' statement` ×8 | `tests/test_mmr_v2_migration.py` | `try/finally: ledger.close()` → `with`; every `.close()` in the file is gone |
| `Suspicious unused loop iteration variable` ×1 | `tests/test_streaming_safety_engine_integration.py` | see below |
| `Module imported with 'import' and 'import from'` ×2 | `tests/compat/`, `tests/licensing/` | single import form in each |

**The unused-loop-variable one was hiding a weak test.** `async for _part in proxy:` discarded what it iterated, which meant the retained-bytes ceiling assertion inside the loop would also have passed vacuously against a proxy that yielded nothing at all. It now sums the emitted bytes and asserts the stream actually ran — the check the loop was reaching for in the first place.

**On the Protocol bodies:** CodeQL reads a bare `...` as dead code. A Protocol member needs *some* body, and a sentence saying what the member is for beats a placeholder, so this is a real improvement rather than a suppression. No `# noqa`, no dismissal, no query-config change.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Security fix
- [ ] Documentation update
- [x] Refactor / code quality

## Evidence contract

- [x] No public claim changed, so `docs/CLAIMS_MATRIX.md` is untouched — these are internal code-quality fixes with no externally observable effect.
- [x] The artifact is the CodeQL run on `#153`'s final head (`a1e320c`), which reported these sixteen notes.
- [x] What this does **not** establish: clearing sixteen notes says nothing about the absence of other findings, and CodeQL's note severity is the lowest it emits. This is not a security fix and should not be described as one.
- [x] No credentials, customer payloads, private endpoints, or synthetic telemetry.

## Verification

- [x] `pytest -q` — **6648 passed / 53 skipped / 1 deselected**, unchanged from `main`.
- [x] `ruff check .` and `ruff format --check .` — clean, 519 files.
- [x] `mypy --strict aegis` — clean, 198 sources.
- [x] `git diff --check` — clean.
- [x] AI-context manifest regenerated and verified.
- [ ] Rust, SDK, dashboard and Helm untouched.

The deselected test is `test_ledger_integrity_property`, a Hypothesis `DeadlineExceeded` on the first example, verified pre-existing at `HEAD` in a clean worktree and left untouched.

## Security and operations

- [x] No threat-model change; no fail-closed path touched.
- [x] Blast radius: one Protocol definition (no runtime behaviour — `Protocol` bodies never execute) and four test files. Rollback is a revert.
- [x] No secrets in the diff.

## Release impact

- [x] No `CHANGELOG.md` entry: nothing here is observable to a user of the software.
- [x] No commercial or buyer-facing language.
- [x] Human reviewer/owner: `@JuanLunaIA`

## Test plan

```bash
pytest -q --deselect tests/test_property_based.py::test_ledger_integrity_property
pytest -q tests/test_mmr_v2_migration.py tests/compat tests/licensing \
         tests/test_streaming_safety_engine_integration.py tests/test_proxy_streaming.py
ruff check . && ruff format --check . && mypy --strict aegis
python scripts/verify_ai_context_manifest.py
```

## Still outstanding from MISSION ORDER III

Not in this PR and not started: **A3** (CryptoShredder into the ledger commit path — a WAL-schema change, since enabling it means the WAL stores ciphertext rather than only hashes), **B1** (`ml-dsa` migration; note the latest published version is **0.1.1**, not the `0.2` the order names), **C1/D1–D4** (gossip consensus, ZK-SNARKs, TEE enclaves, PQ TLS ingress, OpenTelemetry — each a multi-week feature, and the order's own axiom forbids mock-only implementations, so no stubs were added), and **E1** (PyPI wheel determinism).

The stale `docs/comprehensive-corpus-synchronization` branch still exists: every `push --delete` fails with `send-pack: unexpected disconnect` through this environment's git proxy, and the GitHub tools available here expose no delete-branch call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXm9uxZjTkDFnaV6U8R9oa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXm9uxZjTkDFnaV6U8R9oa)_

## Summary by Sourcery

Clean up the sixteen CodeQL notes introduced by the previous change without altering production behavior.

Bug Fixes:
- Strengthen the streaming safety integration test so it verifies that redacted content was actually emitted instead of passing vacuously when the stream yields no data.

Enhancements:
- Replace placeholder Protocol member bodies with descriptive documentation.
- Use context managers for ledger lifecycle management throughout the MMR migration tests.
- Standardize module import styles in compatibility and licensing tests.

Tests:
- Improve streaming integration-test coverage by asserting emitted redacted payloads and reusing shared SSE content parsing.